### PR TITLE
feat: implement CEL integration, DLQ support, and datasource tracking…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to the pipestream-protos project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+#### CEL (Common Expression Language) Integration
+- **GraphEdge.condition**: Enhanced documentation to specify CEL expression usage with `org.projectnessie.cel:cel-tools` for Java/Quarkus implementation. Available context variables: `document`, `metadata`, `context_params`.
+- **NodeProcessingConfig.filter_condition** (field 6): New CEL expression field for document filtering before node processing. When evaluates to false, documents skip the node.
+- **TransformConfig.cel_expression** (field 3): New CEL expression field for flexible field transformations. Available context: `value`, `document`, `metadata`.
+
+#### GraphEdge Transport Configuration
+- **GraphEdge.transport_type** (field 8): Transport mechanism override for the edge (MESSAGING or GRPC).
+- **GraphEdge.kafka_topic** (field 9): Custom Kafka topic override for routing.
+- **GraphEdge.max_hops** (field 10): Loop prevention with maximum hop count.
+
+#### Dead Letter Queue (DLQ) Support
+- **DlqConfig**: New message type for configuring DLQ behavior with:
+  - `enabled`: Toggle DLQ handling
+  - `topic_override`: Custom DLQ topic name
+  - `max_retries`: Retry count before DLQ routing
+  - `initial_backoff`, `max_backoff`, `backoff_multiplier`: Exponential backoff settings
+  - `include_payload`: Option to preserve full message for debugging
+- **GraphNode.dlq_config** (field 16): DLQ configuration attachment to graph nodes.
+
+#### StreamMetadata Datasource Tracking
+- **StreamMetadata.datasource_id** (field 9): DataSource identifier for document origin tracking.
+- **StreamMetadata.account_id** (field 10): Account identifier for ownership and access control.
+- **StreamMetadata.entry_node_id** (field 11): Entry node identifier for tracking pipeline entry points.
+
+#### Engine Service Enhancements
+- **EngineV1Service.IntakeHandoff**: New RPC for intake-to-engine stream handoff with datasource routing.
+- **IntakeHandoffRequest**: Request message with stream, datasource_id, account_id, target override, and priority.
+- **IntakeHandoffResponse**: Response with acceptance status, assigned stream ID, entry node, and queue depth.
+
+#### Pipeline Graph Versioning
+- **PipelineGraph.version** (field 10): Version number for optimistic locking to detect concurrent modifications.
+
+### Deprecated
+
+- **TransformConfig.rule_name** (field 1): Use `cel_expression` for new transformations.
+- **TransformConfig.params** (field 2): Use `cel_expression` for new transformations.
+
+### Migration Notes
+
+#### TransformConfig Migration
+Existing implementations using `rule_name` and `params` will continue to work but should migrate to `cel_expression`:
+
+| Legacy rule_name | CEL Expression Equivalent |
+|------------------|---------------------------|
+| `uppercase` | `value.upperAscii()` |
+| `lowercase` | `value.lowerAscii()` |
+| `trim` | `value.trim()` |
+| `substring` | `value.substring(start, end)` |
+
+#### Field Number Safety
+All new fields use previously unassigned field numbers:
+- GraphEdge: 8, 9, 10
+- GraphNode: 16
+- NodeProcessingConfig: 6
+- PipelineGraph: 10
+- StreamMetadata: 9, 10, 11
+- TransformConfig: 3
+
+No breaking changes to wire format compatibility.

--- a/common/proto/ai/pipestream/data/v1/pipeline_core_types.proto
+++ b/common/proto/ai/pipestream/data/v1/pipeline_core_types.proto
@@ -291,7 +291,8 @@ enum ChecksumType {
 
 // Metadata for tracking stream processing history and context.
 //
-// Contains execution records, tracing information, and error tracking for a stream.
+// Contains execution records, tracing information, error tracking, and datasource
+// context for a stream.
 message StreamMetadata {
   // Source identifier for validation and tracking.
   string source_id = 2;
@@ -307,6 +308,20 @@ message StreamMetadata {
   optional ErrorData stream_error = 7;
   // Stream-level context parameters for processing.
   map<string, string> context_params = 8;
+  // DataSource identifier for tracking document origin.
+  //
+  // Deterministically derived from account_id and connector type.
+  // Used to route documents to the correct pipeline graph entry point.
+  string datasource_id = 9;
+  // Account identifier for ownership and access control.
+  //
+  // Links this stream to a specific tenant/customer account.
+  string account_id = 10;
+  // Entry node identifier where this stream entered the pipeline.
+  //
+  // Useful for tracking which connector/datasource initiated processing
+  // and for routing decisions in multi-entry-point graphs.
+  string entry_node_id = 11;
 }
 
 // TCP-like packet header for node-to-node document processing.
@@ -386,15 +401,37 @@ enum MappingType {
 }
 
 // Configuration for field transformation mappings.
+//
+// Supports both legacy rule-based transformations (deprecated) and modern CEL expressions.
+// For new implementations, use cel_expression instead of rule_name/params.
 message TransformConfig {
   // Name of the transformation rule to apply.
   //
   // Examples: "uppercase", "trim", "substring", "date_format"
-  string rule_name = 1;
+  // Deprecated: Use cel_expression for new transformations.
+  string rule_name = 1 [deprecated = true];
   // Optional parameters for the transformation rule.
   //
   // Example: for "substring", params could be {"start": 0, "end": 10}
-  optional google.protobuf.Struct params = 2;
+  // Deprecated: Use cel_expression for new transformations.
+  optional google.protobuf.Struct params = 2 [deprecated = true];
+  // CEL expression for field transformation.
+  //
+  // Modern alternative to rule_name/params that provides more flexibility.
+  // Uses org.projectnessie.cel:cel-tools for Java/Quarkus implementation.
+  //
+  // Available context variables:
+  //   - value: The current field value being transformed
+  //   - document: The full PipeDoc for cross-field references
+  //   - metadata: StreamMetadata for processing context
+  //
+  // Example expressions:
+  //   - "value.upperAscii()" - Convert to uppercase
+  //   - "value.trim()" - Remove leading/trailing whitespace
+  //   - "value.substring(0, 100)" - Take first 100 characters
+  //   - "document.search_metadata.title + ' - ' + value" - Concatenate fields
+  //   - "value.matches('^[A-Z].*') ? value : 'N/A'" - Conditional transformation
+  string cel_expression = 3;
 }
 
 // Configuration for field aggregation mappings.
@@ -424,7 +461,7 @@ message SplitConfig {
 
 // Node-specific processing configuration.
 //
-// Defines pre/post mappings and custom configuration for a processing node.
+// Defines pre/post mappings, filtering, and custom configuration for a processing node.
 message NodeProcessingConfig {
   // Node identifier for this configuration.
   string node_id = 1;
@@ -436,6 +473,23 @@ message NodeProcessingConfig {
   Intent intent = 4;
   // Node-specific custom configuration.
   google.protobuf.Any node_config = 5;
+  // CEL expression to filter documents before node processing.
+  //
+  // When this expression evaluates to false, the document skips this node
+  // and proceeds to the next node in the pipeline without processing.
+  // Uses org.projectnessie.cel:cel-tools for Java/Quarkus implementation.
+  //
+  // Available context variables:
+  //   - document: The PipeDoc being processed
+  //   - metadata: StreamMetadata with processing history
+  //   - context_params: Map of context parameters
+  //
+  // Example expressions:
+  //   - "document.search_metadata.language == 'en'" - Only process English docs
+  //   - "document.search_metadata.content_length > 100" - Skip very short docs
+  //   - "has(document.blob_bag)" - Only process docs with binary content
+  //   - "!('skip_ocr' in metadata.context_params)" - Skip if flag is set
+  string filter_condition = 6;
 }
 
 // Vector embedding for a document or document segment.

--- a/config/proto/ai/pipestream/config/v1/pipeline_config_models.proto
+++ b/config/proto/ai/pipestream/config/v1/pipeline_config_models.proto
@@ -61,6 +61,12 @@ message PipelineGraph {
   google.protobuf.Timestamp created_at = 8;
   // Timestamp of last modification.
   google.protobuf.Timestamp modified_at = 9;
+  // Version number for optimistic locking.
+  //
+  // Incremented on each update to detect concurrent modifications.
+  // Clients should read the current version before updates and include it
+  // in update requests. Updates fail if the version doesn't match.
+  int64 version = 10;
 }
 
 // Graph node representing an individual processing step.
@@ -101,6 +107,48 @@ message GraphNode {
   google.protobuf.Timestamp created_at = 14;
   // Timestamp of last modification.
   google.protobuf.Timestamp modified_at = 15;
+  // Dead Letter Queue configuration for failed message handling.
+  //
+  // When enabled, messages that fail processing are routed to a DLQ topic
+  // for later inspection and reprocessing.
+  DlqConfig dlq_config = 16;
+}
+
+// Dead Letter Queue configuration for handling failed messages.
+//
+// Configures how failed messages are handled at a node, including retry behavior
+// and topic routing for messages that exhaust all retry attempts.
+message DlqConfig {
+  // Whether DLQ handling is enabled for this node.
+  //
+  // When false, failed messages are logged but not routed to a DLQ.
+  bool enabled = 1;
+  // Custom DLQ topic name override.
+  //
+  // If not set, defaults to "{node_id}.dlq" naming convention.
+  string topic_override = 2;
+  // Maximum number of retry attempts before sending to DLQ.
+  //
+  // A value of 0 means no retries (immediate DLQ on failure).
+  int32 max_retries = 3;
+  // Initial backoff duration between retry attempts.
+  //
+  // Subsequent retries use exponential backoff based on this value.
+  google.protobuf.Duration initial_backoff = 4;
+  // Maximum backoff duration cap.
+  //
+  // Exponential backoff will not exceed this duration.
+  google.protobuf.Duration max_backoff = 5;
+  // Backoff multiplier for exponential backoff.
+  //
+  // Each retry waits (initial_backoff * multiplier^attempt) up to max_backoff.
+  // Default is 2.0 if not specified.
+  double backoff_multiplier = 6;
+  // Whether to include the original message payload in DLQ records.
+  //
+  // When true, the full PipeStream is preserved for debugging.
+  // When false, only metadata and error info are stored.
+  bool include_payload = 7;
 }
 
 // Graph edge defining a connection between two nodes.
@@ -116,12 +164,40 @@ message GraphEdge {
   string to_node_id = 3;
   // Target cluster ID (optional, for cross-cluster edges).
   string to_cluster_id = 4;
-  // Optional routing condition expression.
+  // CEL (Common Expression Language) condition for routing decisions.
+  //
+  // Evaluated at runtime to determine if this edge should be taken.
+  // Uses org.projectnessie.cel:cel-tools for Java/Quarkus implementation.
+  // Available context variables:
+  //   - document: The PipeDoc being processed
+  //   - metadata: StreamMetadata with processing history
+  //   - context_params: Map of context parameters
+  // Example expressions:
+  //   - "document.search_metadata.language == 'en'"
+  //   - "metadata.context_params['priority'] == 'high'"
+  //   - "document.search_metadata.content_length > 1000"
   string condition = 5;
   // Priority for edge selection when multiple edges exist from the same node.
+  //
+  // Lower values indicate higher priority. When multiple edges have conditions
+  // that evaluate to true, the edge with the lowest priority value is selected.
   int32 priority = 6;
   // Flag indicating whether this edge crosses cluster boundaries.
   bool is_cross_cluster = 7;
+  // Transport mechanism for this edge.
+  //
+  // Specifies how data flows across this edge. Defaults to TRANSPORT_TYPE_MESSAGING.
+  TransportType transport_type = 8;
+  // Kafka topic override for this edge.
+  //
+  // When set, messages are routed through this topic instead of the default
+  // node-based topic naming. Useful for custom routing patterns.
+  string kafka_topic = 9;
+  // Maximum number of hops allowed through this edge.
+  //
+  // Prevents infinite loops in cyclic graph configurations.
+  // A value of 0 means unlimited (use with caution).
+  int32 max_hops = 10;
 }
 
 // Module definition containing metadata and configuration schema.

--- a/engine/proto/ai/pipestream/engine/v1/engine_service.proto
+++ b/engine/proto/ai/pipestream/engine/v1/engine_service.proto
@@ -25,6 +25,13 @@ service EngineV1Service {
 
   // Engine health
   rpc GetHealth(GetHealthRequest) returns (GetHealthResponse);
+
+  // Intake-to-engine stream handoff for datasource routing.
+  //
+  // Called by intake connectors to transfer a document stream to the engine
+  // for processing. Routes to the appropriate entry node based on datasource
+  // configuration.
+  rpc IntakeHandoff(IntakeHandoffRequest) returns (IntakeHandoffResponse);
 }
 
 // Request to process a document at a specific node
@@ -233,4 +240,48 @@ enum SubscriptionStrategy {
   SUBSCRIPTION_STRATEGY_CAPACITY_BASED = 3;
   // Use sticky assignment to keep related topics on the same engine
   SUBSCRIPTION_STRATEGY_TOPIC_AFFINITY = 4;
+}
+
+// Request for intake-to-engine stream handoff.
+//
+// Sent by intake connectors when a document is ready for pipeline processing.
+message IntakeHandoffRequest {
+  // The pipeline stream containing the document to process.
+  ai.pipestream.data.v1.PipeStream stream = 1;
+  // DataSource identifier for routing to the correct entry node.
+  //
+  // Used to determine which pipeline graph and entry node should
+  // receive this document based on datasource configuration.
+  string datasource_id = 2;
+  // Account identifier for ownership context.
+  string account_id = 3;
+  // Optional target entry node override.
+  //
+  // When set, routes directly to this node instead of using
+  // datasource-based routing. Useful for testing and debugging.
+  string target_entry_node_id = 4;
+  // Priority level for this handoff.
+  //
+  // Higher values indicate higher priority. Used for queue ordering
+  // when the engine is under load.
+  int32 priority = 5;
+}
+
+// Response from intake-to-engine stream handoff.
+message IntakeHandoffResponse {
+  // Whether the handoff was accepted.
+  bool accepted = 1;
+  // Status or error message.
+  string message = 2;
+  // Assigned stream ID for tracking.
+  //
+  // May differ from the request stream_id if the engine assigns
+  // a new ID for tracking purposes.
+  string assigned_stream_id = 3;
+  // Entry node ID that will process this document.
+  string entry_node_id = 4;
+  // Estimated queue depth at the entry node.
+  //
+  // Provides feedback to intake connectors for backpressure decisions.
+  int64 queue_depth = 5;
 }


### PR DESCRIPTION
… (#14)

Add comprehensive protobuf updates for CEL-based routing and filtering, dead letter queue configuration, and datasource tracking capabilities.

Changes:
- GraphEdge: Add transport_type, kafka_topic, max_hops fields; document CEL condition expressions with org.projectnessie.cel:cel-tools
- GraphNode: Add dlq_config field for dead letter queue handling
- DlqConfig: New message with retry, backoff, and payload options
- PipelineGraph: Add version field for optimistic locking
- NodeProcessingConfig: Add filter_condition for CEL-based filtering
- TransformConfig: Deprecate rule_name/params, add cel_expression
- StreamMetadata: Add datasource_id, account_id, entry_node_id
- EngineV1Service: Add IntakeHandoff RPC for intake-engine handoff

All changes pass buf lint validation. No breaking wire format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)