### PR TITLE
feat: dual-drive S3 layout proto fields

### DIFF
--- a/repo/proto/ai/pipestream/repository/pipedoc/v1/pipedoc_service.proto
+++ b/repo/proto/ai/pipestream/repository/pipedoc/v1/pipedoc_service.proto
@@ -37,6 +37,13 @@ message SavePipeDocRequest {
 
   // Additional key-value metadata to associate with this document
   map<string, string> metadata = 6;
+
+  // Pipeline graph ID that produced this document (optional).
+  // Used to construct the S3 key path for pipeline-processed documents:
+  //   {accountId}/pipeline/{graphId}/{docId}/{nodeId}/{uuid}.pb
+  // Enables prefix-delete of all documents produced by a specific graph.
+  // Should be set for engine saves; omitted for intake.
+  optional string graph_id = 8;
 }
 
 // Response containing details about the saved PipeDoc and its storage location.

--- a/repo/proto/ai/pipestream/repository/v1/repository_service_data.proto
+++ b/repo/proto/ai/pipestream/repository/v1/repository_service_data.proto
@@ -257,6 +257,16 @@ message PipeDocUpdateNotification {
 
   // Optional per-datasource retention hint (days) for index lifecycle; mirrors RepositoryEvent when set.
   optional int32 retention_intent_days = 12;
+
+  // Drive type: "intake" or "pipeline". Indicates whether this is a source document
+  // from connector upload or a derived document from graph processing.
+  string drive_type = 13;
+
+  // Graph ID that produced this document (empty for intake documents).
+  string graph_id = 14;
+
+  // Cluster ID where this document was processed (empty for intake documents).
+  string cluster_id = 15;
 }
 
 // Event notification for ProcessRequest changes in the repository.

--- a/repo/proto/ai/pipestream/repository/v1/repository_service_data.proto
+++ b/repo/proto/ai/pipestream/repository/v1/repository_service_data.proto
@@ -329,4 +329,14 @@ message CacheFlushEvent {
   string drive_name = 3;
   // Account ID for drive resolution.
   string account_id = 4;
+  // Document ID for S3 metadata tagging.
+  string doc_id = 5;
+  // Connector ID for S3 metadata tagging.
+  string connector_id = 6;
+  // Datasource ID for S3 metadata tagging.
+  string datasource_id = 7;
+  // Cluster ID for S3 metadata tagging (optional).
+  optional string cluster_id = 8;
+  // Graph ID for S3 metadata tagging (optional).
+  optional string graph_id = 9;
 }


### PR DESCRIPTION
## Summary
- Add `optional string graph_id` to `SavePipeDocRequest` for graph-scoped S3 key paths
- Add `doc_id`, `connector_id`, `datasource_id`, `cluster_id`, `graph_id` to `CacheFlushEvent` for complete S3 metadata on Redis-buffered writes
- Add `drive_type`, `graph_id`, `cluster_id` to `PipeDocUpdateNotification` for OpenSearch telemetry indexing

## Consuming repos (all on `feature/dual-drive-s3-layout` branch)
- repository-service
- pipestream-engine
- connector-intake-service
- pipestream-opensearch

## Test plan
- [x] All consuming repos compile and pass tests against this branch
- [x] Live E2E crawl verified new S3 key layout and metadata headers