### PR TITLE
feat: cleanup test data RPCs

### DIFF
--- a/intake/proto/ai/pipestream/connector/intake/v1/connector_intake_service.proto
+++ b/intake/proto/ai/pipestream/connector/intake/v1/connector_intake_service.proto
@@ -139,6 +139,10 @@ service DataSourceAdminService {
 
   // Get connector type details including schema and capabilities.
   rpc GetConnectorType(GetConnectorTypeRequest) returns (GetConnectorTypeResponse);
+
+  // Delete all datasources whose account_id starts with the given prefix.
+  // Intended for cleaning up test data (e.g., prefix = "jdbc-e2e-" or "transport-e2e-").
+  rpc CleanupTestDataSources(CleanupTestDataSourcesRequest) returns (CleanupTestDataSourcesResponse);
 }
 
 // ============================================
@@ -735,4 +739,21 @@ message CrawlSessionSummary {
   string status = 9;
   // Additional metadata as key-value pairs.
   map<string, string> metadata = 10;
+}
+
+// --- CleanupTestDataSources ---
+
+message CleanupTestDataSourcesRequest {
+  // Prefix to match against account_id (e.g., "jdbc-e2e-" or "transport-e2e-").
+  // All datasources whose account_id starts with this prefix will be hard-deleted.
+  string account_id_prefix = 1;
+}
+
+message CleanupTestDataSourcesResponse {
+  bool success = 1;
+  string message = 2;
+  // Number of datasources deleted.
+  int32 datasources_deleted = 3;
+  // IDs of deleted datasources.
+  repeated string deleted_datasource_ids = 4;
 }

--- a/jdbc-connector/proto/ai/pipestream/connector/jdbc/v1/jdbc_crawl_events.proto
+++ b/jdbc-connector/proto/ai/pipestream/connector/jdbc/v1/jdbc_crawl_events.proto
@@ -115,6 +115,10 @@ service JdbcConnectorControlService {
 
   // List all crawl definitions (config-seeded and runtime-created).
   rpc ListCrawlDefinitions(ListCrawlDefinitionsRequest) returns (ListCrawlDefinitionsResponse);
+
+  // Delete all crawl definitions whose crawl_name starts with the given prefix.
+  // Intended for cleaning up test data (e.g., prefix = "e2e-").
+  rpc CleanupTestCrawls(CleanupTestCrawlsRequest) returns (CleanupTestCrawlsResponse);
 }
 
 // --- StartCrawl ---
@@ -305,4 +309,25 @@ message CrawlDefinitionInfo {
   string crawl_mode = 8;
   bool seeded_from_config = 9;
   string status = 10;
+}
+
+// --- CleanupTestCrawls ---
+
+message CleanupTestCrawlsRequest {
+  // Prefix to match against crawl_name (e.g., "e2e-" or "test-").
+  // All crawl definitions whose name starts with this prefix will be deleted.
+  string crawl_name_prefix = 1;
+  // If true, also delete the associated datasources via connector-admin.
+  bool delete_datasources = 2;
+}
+
+message CleanupTestCrawlsResponse {
+  bool success = 1;
+  string message = 2;
+  // Number of crawl definitions deleted.
+  int32 crawls_deleted = 3;
+  // Number of datasources deleted (if delete_datasources was true).
+  int32 datasources_deleted = 4;
+  // Names of deleted crawl definitions.
+  repeated string deleted_crawl_names = 5;
 }


### PR DESCRIPTION
## Summary
- `JdbcConnectorControlService.CleanupTestCrawls` — deletes crawl definitions by name prefix
- `DataSourceAdminService.CleanupTestDataSources` — deletes datasources by account_id prefix
- Both intended for cleaning up stale test data (e2e-, transport-e2e-, etc.)

## Test plan
- [ ] Implement in jdbc-connector and connector-admin