### PR TITLE
proto: bulk indexing queue config, E2E tuning overrides, kafka partitions

### DIFF
--- a/config/proto/ai/pipestream/config/v1/pipeline_config_models.proto
+++ b/config/proto/ai/pipestream/config/v1/pipeline_config_models.proto
@@ -147,6 +147,15 @@ message GraphNode {
   // When true, the document is persisted to the repository even if the module
   // processing encounters an error. Useful for debugging and reprocessing.
   bool save_on_error = 19;
+
+  // Number of Kafka partitions for this node's processing topic.
+  //
+  // Only relevant when this node is the target of at least one MESSAGING edge.
+  // More partitions enable higher parallelism across sidecar consumers.
+  // If 0 or unset, defaults to pipestream.kafka.default-partitions (engine config, default 4).
+  // Once the topic exists, this value is NOT used to alter it — changing partitions
+  // on an existing topic requires a separate admin operation.
+  int32 kafka_partitions = 20;
 }
 
 // Dead Letter Queue configuration for handling failed messages.

--- a/opensearch/proto/ai/pipestream/opensearch/v1/opensearch_manager.proto
+++ b/opensearch/proto/ai/pipestream/opensearch/v1/opensearch_manager.proto
@@ -46,6 +46,11 @@ service OpenSearchManagerService {
   // Searches document uploads (repository-document-uploads index).
   // Account scoping is derived from the security context (x-account-id header), NOT from the request.
   rpc SearchDocumentUploads(SearchDocumentUploadsRequest) returns (SearchDocumentUploadsResponse);
+
+  // Retrieves the current bulk indexing queue configuration.
+  rpc GetBulkConfig(GetBulkConfigRequest) returns (GetBulkConfigResponse);
+  // Updates the bulk indexing queue configuration at runtime (queue count, capacity, flush interval).
+  rpc UpdateBulkConfig(UpdateBulkConfigRequest) returns (UpdateBulkConfigResponse);
 }
 
 // === Schema Management Messages (from schema_manager.proto) ===
@@ -409,4 +414,36 @@ message DocumentUploadResult {
   int64 uploaded_at = 8;
   // Search relevance score
   float score = 9;
+}
+
+// === Bulk Indexing Configuration ===
+
+// Runtime configuration for the bulk indexing queue system.
+message BulkIndexingConfig {
+  // Number of concurrent draining queues (range: 2-10, default: 4)
+  int32 queue_count = 1;
+  // Maximum items per queue before forced flush (default: 200)
+  int32 queue_capacity = 2;
+  // Milliseconds between periodic flush sweeps (default: 2000)
+  int32 flush_interval_ms = 3;
+}
+
+// Request to update the bulk indexing queue configuration at runtime.
+message UpdateBulkConfigRequest {
+  BulkIndexingConfig config = 1;
+}
+
+// Response from bulk config update with the active configuration.
+message UpdateBulkConfigResponse {
+  bool success = 1;
+  BulkIndexingConfig active_config = 2;
+  string message = 3;
+}
+
+// Request to retrieve the current bulk indexing configuration.
+message GetBulkConfigRequest {}
+
+// Response containing the current bulk indexing configuration.
+message GetBulkConfigResponse {
+  BulkIndexingConfig config = 1;
 }

--- a/testing-harness/proto/ai/pipestream/testing/harness/v1/testing_harness_service.proto
+++ b/testing-harness/proto/ai/pipestream/testing/harness/v1/testing_harness_service.proto
@@ -105,6 +105,17 @@ message RunE2EPipelineTestRequest {
   // When true, adds a SEMANTIC algorithm directive that uses sentence-level
   // embedding similarity for topic boundary detection, plus centroid vectors.
   bool include_semantic_chunking = 9;
+
+  // OpenSearch index creation settings for vector chunk indices.
+  optional OpenSearchIndexSettings opensearch_settings = 10;
+
+  // OpenSearch bulk indexing queue configuration for this test run.
+  // If set, calls UpdateBulkConfig on opensearch-manager before the test starts.
+  optional ai.pipestream.opensearch.v1.BulkIndexingConfig bulk_indexing = 11;
+
+  // Number of Kafka partitions for graph node processing topics.
+  // Only relevant when transport_type = KAFKA.
+  int32 kafka_partitions = 12;
 }
 
 // Streamed response for each step of the E2E pipeline test.
@@ -300,6 +311,18 @@ message RunS3CrawlTestRequest {
   // When true, adds a SEMANTIC algorithm directive that uses sentence-level
   // embedding similarity for topic boundary detection, plus centroid vectors.
   bool include_semantic_chunking = 12;
+
+  // OpenSearch index creation settings for vector chunk indices.
+  // Controls shards, replicas, refresh interval, and HNSW parameters.
+  optional OpenSearchIndexSettings opensearch_settings = 13;
+
+  // OpenSearch bulk indexing queue configuration for this test run.
+  // If set, calls UpdateBulkConfig on opensearch-manager before the crawl starts.
+  optional ai.pipestream.opensearch.v1.BulkIndexingConfig bulk_indexing = 14;
+
+  // Number of Kafka partitions for graph node processing topics.
+  // Only relevant when transport_type = KAFKA.
+  int32 kafka_partitions = 15;
 }
 
 // Streamed response for each step of the S3 crawl test.

--- a/testing-harness/proto/ai/pipestream/testing/harness/v1/testing_harness_service.proto
+++ b/testing-harness/proto/ai/pipestream/testing/harness/v1/testing_harness_service.proto
@@ -5,6 +5,7 @@ package ai.pipestream.testing.harness.v1;
 import "ai/pipestream/connector/s3/v1/s3_connector_control.proto";
 import "ai/pipestream/data/module/v1/module_service.proto";
 import "ai/pipestream/data/v1/pipeline_core_types.proto";
+import "ai/pipestream/opensearch/v1/opensearch_manager.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -219,6 +220,16 @@ message RunJdbcCrawlTestRequest {
   // Controls shards, replicas, refresh interval, and HNSW parameters.
   // If not set, opensearch-manager defaults apply (from application.properties).
   optional OpenSearchIndexSettings opensearch_settings = 16;
+
+  // OpenSearch bulk indexing queue configuration for this test run.
+  // If set, calls UpdateBulkConfig on opensearch-manager before the crawl starts.
+  // Controls queue count, capacity, and flush interval for the draining queue system.
+  optional ai.pipestream.opensearch.v1.BulkIndexingConfig bulk_indexing = 17;
+
+  // Number of Kafka partitions for graph node processing topics.
+  // Only relevant when transport_type = KAFKA. Applied to all graph nodes created by the test.
+  // If 0 or unset, uses the engine default (pipestream.kafka.default-partitions, default 4).
+  int32 kafka_partitions = 18;
 }
 
 // OpenSearch index creation settings for performance tuning.

--- a/testing-harness/proto/ai/pipestream/testing/harness/v1/testing_harness_service.proto
+++ b/testing-harness/proto/ai/pipestream/testing/harness/v1/testing_harness_service.proto
@@ -214,6 +214,30 @@ message RunJdbcCrawlTestRequest {
   // When true, adds a SEMANTIC algorithm directive that uses sentence-level
   // embedding similarity for topic boundary detection, plus centroid vectors.
   bool include_semantic_chunking = 15;
+
+  // OpenSearch index creation settings for vector chunk indices.
+  // Controls shards, replicas, refresh interval, and HNSW parameters.
+  // If not set, opensearch-manager defaults apply (from application.properties).
+  optional OpenSearchIndexSettings opensearch_settings = 16;
+}
+
+// OpenSearch index creation settings for performance tuning.
+// See: https://docs.opensearch.org/latest/vector-search/performance-tuning-indexing/
+message OpenSearchIndexSettings {
+  // Number of primary shards for chunk indices. More = parallel HNSW construction. Default: 8.
+  optional int32 number_of_shards = 1;
+
+  // Number of replicas. 0 during bulk indexing avoids duplicate HNSW graph construction.
+  optional int32 number_of_replicas = 2;
+
+  // Refresh interval. "-1" disables during bulk indexing to avoid tiny segments. Default: "-1".
+  optional string refresh_interval = 3;
+
+  // HNSW ef_construction: graph build quality. Lower = faster indexing. Default: 100.
+  optional int32 ef_construction = 4;
+
+  // HNSW m: bidirectional links per node. Default: 16.
+  optional int32 hnsw_m = 5;
 }
 
 // =====================================================================


### PR DESCRIPTION
## Summary

Proto additions to support the bulk indexing queue work across opensearch-manager, the engine, and the testing sidecar. All changes are additive; no breaking changes to existing fields.

- `BulkIndexingConfig` message + `GetBulkConfig`/`UpdateBulkConfig` RPCs on `OpenSearchManagerService` — runtime tuning of the concurrent bulk queue system (queue count, capacity, flush interval)
- `OpenSearchIndexSettings` message — per-run index creation knobs (shards, replicas, refresh interval, HNSW params)
- `GraphNode.kafka_partitions` (field 20) — per-node partition count for Kafka processing topics; consumed by the engine's `KafkaTopicRegistrar`
- `RunJdbcCrawlTestRequest`, `RunS3CrawlTestRequest`, `RunE2EPipelineTestRequest` each gain `opensearch_settings`, `bulk_indexing`, `kafka_partitions` for E2E tuning overrides from the testing sidecar FE

## Commits

- proto: add BulkIndexingConfig messages and GetBulkConfig/UpdateBulkConfig RPCs
- proto: add OpenSearchIndexSettings to RunJdbcCrawlTestRequest for E2E tuning
- proto: add GraphNode.kafka_partitions for configurable topic partition count
- proto: add bulk_indexing and kafka_partitions fields to RunJdbcCrawlTestRequest
- proto: add tuning fields to RunS3CrawlTestRequest and RunE2EPipelineTestRequest

## Test plan

- [x] buf build
- [x] buf lint
- [x] Consumed from opensearch-manager worktree (generates cleanly, full test suite passes)
- [x] Consumed from engine worktree (compiles, KafkaTopicRegistrar wires kafka_partitions)
- [x] Consumed from testing-sidecar worktree (compiles, E2E runner wires all three override fields)