### PR TITLE
proto: split document classification + solidify quality models

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -24,6 +24,8 @@ modules:
     name: buf.build/pipestreamai/parser
   - path: pipeline-module/proto
     name: buf.build/pipestreamai/pipeline-module
+  - path: quality/proto
+    name: buf.build/pipestreamai/quality
   - path: registration/proto
     name: buf.build/pipestreamai/registration
   - path: repo/proto

--- a/common/proto/ai/pipestream/data/v1/creative_commons_license.proto
+++ b/common/proto/ai/pipestream/data/v1/creative_commons_license.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package ai.pipestream.data.v1;
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "CreativeCommonsLicense";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // Creative Commons REL
@@ -39,13 +39,13 @@ message CreativeCommonsClassification {
   // Creative Commons license family.
   enum License {
     LICENSE_UNSPECIFIED = 0;
-    LICENSE_CC0 = 1;           // Public Domain Dedication
-    LICENSE_PDM = 2;           // Public Domain Mark
-    LICENSE_BY = 3;            // Attribution
-    LICENSE_BY_SA = 4;         // Attribution-ShareAlike
-    LICENSE_BY_NC = 5;         // Attribution-NonCommercial
-    LICENSE_BY_ND = 6;         // Attribution-NoDerivs
-    LICENSE_BY_NC_SA = 7;      // Attribution-NonCommercial-ShareAlike
-    LICENSE_BY_NC_ND = 8;      // Attribution-NonCommercial-NoDerivs
+    LICENSE_CC0 = 1; // Public Domain Dedication
+    LICENSE_PDM = 2; // Public Domain Mark
+    LICENSE_BY = 3; // Attribution
+    LICENSE_BY_SA = 4; // Attribution-ShareAlike
+    LICENSE_BY_NC = 5; // Attribution-NonCommercial
+    LICENSE_BY_ND = 6; // Attribution-NoDerivs
+    LICENSE_BY_NC_SA = 7; // Attribution-NonCommercial-ShareAlike
+    LICENSE_BY_NC_ND = 8; // Attribution-NonCommercial-NoDerivs
   }
 }

--- a/common/proto/ai/pipestream/data/v1/creative_commons_license.proto
+++ b/common/proto/ai/pipestream/data/v1/creative_commons_license.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "CreativeCommonsLicense";
+
+// =============================================================================
+// Creative Commons REL
+// =============================================================================
+//
+// Creative Commons Rights Expression Language.
+// https://creativecommons.org/ns
+//
+// Models the license identifier plus version and optional jurisdiction (port).
+// Version is a string (not enum) because license versions are an open evolution
+// point. Jurisdiction is a string (ISO 3166-1 alpha-2 code) because country
+// codes are an open, evolving set.
+//
+// Owned by this standard: the License enum (closed family of 8 licenses).
+// =============================================================================
+
+message CreativeCommonsClassification {
+  // Which CC license applies. Enum because the license family is a bounded,
+  // stable set.
+  License license = 1;
+
+  // License version as a string. Expected values: "1.0", "2.0", "2.5", "3.0",
+  // "4.0". Kept as string to avoid breaking old consumers when a new CC
+  // version ships.
+  optional string version = 2;
+
+  // Optional jurisdiction port as an ISO 3166-1 alpha-2 country code.
+  // Empty = unported / international version. Kept as string because the
+  // ISO 3166-1 set evolves over time (new country codes, deprecated codes).
+  optional string jurisdiction = 3;
+
+  // Creative Commons license family.
+  enum License {
+    LICENSE_UNSPECIFIED = 0;
+    LICENSE_CC0 = 1;           // Public Domain Dedication
+    LICENSE_PDM = 2;           // Public Domain Mark
+    LICENSE_BY = 3;            // Attribution
+    LICENSE_BY_SA = 4;         // Attribution-ShareAlike
+    LICENSE_BY_NC = 5;         // Attribution-NonCommercial
+    LICENSE_BY_ND = 6;         // Attribution-NoDerivs
+    LICENSE_BY_NC_SA = 7;      // Attribution-NonCommercial-ShareAlike
+    LICENSE_BY_NC_ND = 8;      // Attribution-NonCommercial-NoDerivs
+  }
+}

--- a/common/proto/ai/pipestream/data/v1/dcmi_terms.proto
+++ b/common/proto/ai/pipestream/data/v1/dcmi_terms.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package ai.pipestream.data.v1;
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "DcmiTerms";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // Dublin Core Terms (DCMI) — Rights & Access subset

--- a/common/proto/ai/pipestream/data/v1/dcmi_terms.proto
+++ b/common/proto/ai/pipestream/data/v1/dcmi_terms.proto
@@ -1,0 +1,70 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "DcmiTerms";
+
+// =============================================================================
+// Dublin Core Terms (DCMI) — Rights & Access subset
+// =============================================================================
+//
+// DCMI Metadata Terms
+// https://www.dublincore.org/specifications/dublin-core/dcmi-terms/
+//
+// Models the rights and access subset of DCMI Metadata Terms. The other ~50
+// terms (title, creator, subject, etc.) are catalog concerns and do not
+// belong in classification metadata — those live in the parser-side
+// `ai.pipestream.parsed.data.dublin.v1.DublinCoreMetadata`, which holds the
+// basic 15-element Dublin Core extracted by parsers like Tika.
+//
+// This file is named `dcmi_terms` rather than `dublin_core` to disambiguate
+// from the parser-side file, and because the refinement terms modeled here
+// (rightsHolder, license, accessRights, provenance) are DCMI Metadata Terms
+// extensions beyond the 15 base Dublin Core elements.
+//
+// Owned by this standard: the CoarAccessRights enum. DCMI recommends the
+// COAR Access Rights Vocabulary for dcterms:accessRights, and COAR defines
+// a closed 4-value SKOS concept scheme.
+// Source: https://coar-repositories.github.io/vocabularies-access-rights/
+// =============================================================================
+
+message DublinCoreClassification {
+  // dcterms:rights — a statement about rights held in and over the resource.
+  // Free text or URI per DCMI (no controlled vocabulary).
+  optional string rights = 1;
+
+  // dcterms:license — a legal document giving official permission to use.
+  // URI per DCMI (no controlled vocabulary).
+  optional string license = 2;
+
+  // dcterms:rightsHolder — a person or organization owning or managing rights.
+  // Free text per DCMI.
+  optional string rights_holder = 3;
+
+  // dcterms:accessRights — information about who can access the resource.
+  // DCMI recommends the COAR Access Rights Vocabulary for this field,
+  // which is modeled below as CoarAccessRights.
+  optional CoarAccessRights access_rights = 4;
+
+  // dcterms:provenance — a statement of changes in ownership and custody.
+  // Free text per DCMI.
+  optional string provenance = 5;
+
+  // COAR Access Rights Vocabulary — DCMI-recommended controlled vocabulary
+  // for dcterms:accessRights. Closed 4-value SKOS concept scheme.
+  //
+  // Source: https://coar-repositories.github.io/vocabularies-access-rights/
+  enum CoarAccessRights {
+    COAR_ACCESS_RIGHTS_UNSPECIFIED = 0;
+    // http://purl.org/coar/access_right/c_abf2
+    COAR_ACCESS_RIGHTS_OPEN_ACCESS = 1;
+    // http://purl.org/coar/access_right/c_f1cf
+    COAR_ACCESS_RIGHTS_EMBARGOED_ACCESS = 2;
+    // http://purl.org/coar/access_right/c_16ec
+    COAR_ACCESS_RIGHTS_RESTRICTED_ACCESS = 3;
+    // http://purl.org/coar/access_right/c_14cb
+    COAR_ACCESS_RIGHTS_METADATA_ONLY_ACCESS = 4;
+  }
+}

--- a/common/proto/ai/pipestream/data/v1/document_classification.proto
+++ b/common/proto/ai/pipestream/data/v1/document_classification.proto
@@ -1,0 +1,201 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+import "google/protobuf/timestamp.proto";
+
+import "ai/pipestream/data/v1/creative_commons_license.proto";
+import "ai/pipestream/data/v1/dcmi_terms.proto";
+import "ai/pipestream/data/v1/ead_rights.proto";
+import "ai/pipestream/data/v1/mods_access_condition.proto";
+import "ai/pipestream/data/v1/odrl_policy.proto";
+import "ai/pipestream/data/v1/premis_rights.proto";
+import "ai/pipestream/data/v1/rights_statements.proto";
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "DocumentClassification";
+
+// =============================================================================
+// Document Classification — Thin Aggregator
+// =============================================================================
+//
+// This file is deliberately thin. It defines only:
+//
+//   1. UseRestriction — the enforcement-level policy enum that every module
+//      writing persistent state MUST check.
+//   2. StandardClassification — a wrapper that unions the seven first-class
+//      standards (each defined in its own sibling proto file) plus a
+//      CustomClassification escape hatch.
+//   3. CustomClassification — escape hatch for standards not yet first-classed.
+//
+// The seven first-class standards live in sibling files so that each standard
+// is self-contained with its own XSD citations and extensibility rules.
+// Filenames are suffixed with the specific concept each file models to keep
+// bare filenames unique across the whole proto tree (some tooling resolves
+// imports by unqualified filename):
+//
+//   - dcmi_terms.proto              -> DublinCoreClassification (+ CoarAccessRights)
+//   - premis_rights.proto           -> PremisClassification (+ PremisStringPlusAuthority)
+//   - ead_rights.proto              -> EadClassification
+//   - mods_access_condition.proto   -> ModsClassification
+//   - odrl_policy.proto             -> OdrlClassification (+ Operator)
+//   - rights_statements.proto       -> RightsStatementsClassification (+ Statement)
+//   - creative_commons_license.proto -> CreativeCommonsClassification (+ License)
+//
+// Note on Dublin Core: the parser-side `ai.pipestream.parsed.data.dublin.v1`
+// package holds `DublinCoreMetadata` (basic 15-element DC extracted by parsers
+// like Tika). That's a catalog concern. The classification-side is
+// `DublinCoreClassification` in dcmi_terms.proto, which models the DCMI
+// Metadata Terms rights/access refinements (license, rightsHolder,
+// accessRights with COAR vocabulary, provenance). Different packages,
+// different purposes, different filenames to avoid confusion.
+//
+// Design principles for this file:
+//
+//   Controlled vocabulary principle:
+//     If a standard defines a bounded, stable set of allowed values, model it
+//     as an enum (in the owning standard's file). If a field is intentionally
+//     free text per the standard, it stays a string. Version identifiers stay
+//     strings because they are an open evolution point.
+//
+//   Escape hatch principle:
+//     CustomClassification exists ONLY for genuine extensibility — standards
+//     not yet first-classed. It MUST NOT be used to avoid properly modeling
+//     a controlled vocabulary. When a "custom" value sees repeated use,
+//     promote it to a first-class standard file in a future proto revision.
+//
+//   No-bleeding principle:
+//     These classification types are independent of parser-specific metadata
+//     models (Tika, Docling, etc.). If parser output needs to be translated
+//     into a StandardClassification, the translation is performed by external
+//     mapper code — NEVER by importing parser-specific protos here.
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// 1. Enforcement-level use restrictions
+// -----------------------------------------------------------------------------
+
+// Machine-actionable use restrictions enforced at every persistence decision
+// point by every pipeline module that writes recoverable state.
+//
+// Modules MUST:
+//   - Check use_restrictions before writing to caches, DLQ payloads,
+//     save_on_error storage, audit trail content fields, etc.
+//   - Fail closed (FAILED_PRECONDITION) on any unknown enum value they
+//     encounter, rather than silently ignoring it. This preserves fail-safe
+//     semantics as the enum evolves across platform versions.
+//
+// Aligned with archival tradition (EAD <userestrict>, DACS 5.6 "Conditions
+// Governing Use") for interop with finding-aid metadata systems.
+enum UseRestriction {
+  USE_RESTRICTION_UNSPECIFIED = 0;
+
+  // Content may not be retained in any recoverable form beyond what the
+  // pipeline needs for in-flight processing.
+  //
+  // Enforcement (every downstream module MUST honor):
+  //   - Chunker cache writes suppressed
+  //   - Embedder cache writes suppressed
+  //   - save_on_error payload storage suppressed (ID + status only)
+  //   - DLQ payloads stripped of content fields
+  //   - Audit trails may record doc_id and status but NOT text content
+  //   - Retries must re-read from source; no recoverable payload in transit
+  //   - Cache READS remain permitted — cached vectors derived from identical
+  //     text of a non-restricted doc contain no identifying payload
+  //
+  // Regulatory basis:
+  //   US: Privacy Act of 1974 § 552a; FOIA exemption (b)(6) (personal privacy);
+  //       GLBA § 501(b) (consumer financial privacy); 12 CFR 261 access
+  //       determinations
+  //   EU: GDPR Article 17 (Right to Erasure)
+  //
+  // Archival metadata mappings:
+  //   EAD:    <userestrict type="privacy">
+  //   MODS:   <accessCondition type="restriction on access">
+  //   PREMIS: rightsBasis=Statute; rightsGranted.act=delete-on-request
+  //   ODRL:   prohibition=reproduce + duty=delete
+  USE_RESTRICTION_NO_RECOVERABLE_PERSISTENCE = 1;
+}
+
+// -----------------------------------------------------------------------------
+// 2. Standards-aligned classification wrapper
+// -----------------------------------------------------------------------------
+
+// A single classification statement in one formal standard's native format.
+// Wraps the seven first-class standards via oneof, with a CustomClassification
+// escape hatch for standards not yet promoted to first-class.
+//
+// A document may carry multiple StandardClassification entries (e.g. one
+// Dublin Core rights statement + one PREMIS Rights Statement + one Creative
+// Commons license). The outer container on OwnershipContext is repeated.
+message StandardClassification {
+  // Version of the standard this classification conforms to.
+  //
+  // Left as a string (not enum) because standards versions are an open
+  // evolution point: enum'ing them would force a proto revision every time
+  // a standard publishes a new revision, and old consumers would silently
+  // lose information when they deserialized messages using new enum values.
+  //
+  // Expected formats per standard:
+  //   dublin_core       - "1.1" (DCMI Metadata Terms)
+  //   premis            - "3.0" (PREMIS Data Dictionary)
+  //   ead               - "2002" or "3"
+  //   mods              - "3.7"
+  //   odrl              - "2.2"
+  //   rights_statements - "1.0"
+  //   creative_commons  - the CC license version, e.g. "4.0"
+  optional string standard_version = 1;
+
+  // The classification itself, in the chosen standard's shape.
+  oneof content {
+    DublinCoreClassification dublin_core = 2;
+    PremisClassification premis = 3;
+    EadClassification ead = 4;
+    ModsClassification mods = 5;
+    OdrlClassification odrl = 6;
+    RightsStatementsClassification rights_statements = 7;
+    CreativeCommonsClassification creative_commons = 8;
+
+    // Escape hatch for standards not yet first-classed. Consumers should
+    // prefer the first-class branches where available. If a particular
+    // custom standard_id is seen repeatedly in production, promote it to
+    // a first-class branch in a future proto revision.
+    CustomClassification custom = 100;
+  }
+
+  // Identifier for the component that stamped this classification.
+  // Free-form because it identifies a tool or process, not a controlled set.
+  // Examples: "connector/oai-pmh", "ingestion/ead-import", "manual-curator",
+  // "mapper/tika-to-dublin-core". MUST NOT reference parser internals directly.
+  optional string source = 200;
+
+  // When this classification was applied to the document.
+  optional google.protobuf.Timestamp applied_at = 201;
+}
+
+// -----------------------------------------------------------------------------
+// 3. Custom classification escape hatch
+// -----------------------------------------------------------------------------
+//
+// For standards not yet first-classed. Using this branch loses the
+// type-safety benefits of the modeled standards above. If a particular
+// standard_id is seen repeatedly, promote it to a first-class sub-message
+// in a future proto revision.
+
+message CustomClassification {
+  // Free-form identifier for the standard, including version.
+  // Examples: "archive-org/1.0", "marc21/rights", "internal-fooco/2"
+  string standard_id = 1;
+
+  // Serialized content in the standard's native format.
+  string content = 2;
+
+  // MIME type hint for content.
+  // Common values: "application/xml", "text/uri-list",
+  // "application/rdf+xml", "application/json", "text/plain"
+  string content_type = 3;
+
+  // Extensibility for structured extras not captured in content.
+  map<string, string> properties = 4;
+}

--- a/common/proto/ai/pipestream/data/v1/document_classification.proto
+++ b/common/proto/ai/pipestream/data/v1/document_classification.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package ai.pipestream.data.v1;
 
-import "google/protobuf/timestamp.proto";
-
 import "ai/pipestream/data/v1/creative_commons_license.proto";
 import "ai/pipestream/data/v1/dcmi_terms.proto";
 import "ai/pipestream/data/v1/ead_rights.proto";
@@ -11,10 +9,11 @@ import "ai/pipestream/data/v1/mods_access_condition.proto";
 import "ai/pipestream/data/v1/odrl_policy.proto";
 import "ai/pipestream/data/v1/premis_rights.proto";
 import "ai/pipestream/data/v1/rights_statements.proto";
+import "google/protobuf/timestamp.proto";
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "DocumentClassification";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // Document Classification — Thin Aggregator

--- a/common/proto/ai/pipestream/data/v1/ead_rights.proto
+++ b/common/proto/ai/pipestream/data/v1/ead_rights.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package ai.pipestream.data.v1;
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "EadRights";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // EAD (Encoded Archival Description)

--- a/common/proto/ai/pipestream/data/v1/ead_rights.proto
+++ b/common/proto/ai/pipestream/data/v1/ead_rights.proto
@@ -1,0 +1,107 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "EadRights";
+
+// =============================================================================
+// EAD (Encoded Archival Description)
+// =============================================================================
+//
+// EAD3 — Library of Congress / Society of American Archivists
+// https://www.loc.gov/ead/
+// XSD: https://github.com/SAA-SDT/EAD3/blob/master/ead3.xsd
+//
+// Models only the rights/access subset: <accessrestrict>, <userestrict>,
+// <legalstatus>. Other EAD3 elements (~150 total) describe finding-aid
+// structure and are not classification metadata.
+//
+// EAD3 DOES NOT prescribe a controlled vocabulary for any of these
+// elements' content or attributes. The three elements share identical
+// shapes in the XSD — free mixed content (m.blocks: paragraphs, lists,
+// chronologies) plus an @localtype attribute of type xs:token which is
+// explicitly institution-defined:
+//
+//   <xs:complexType name="legalstatus">
+//     <xs:sequence>
+//       <xs:element name="head" type="head" minOccurs="0"/>
+//       <xs:choice maxOccurs="unbounded">
+//         <xs:group ref="m.blocks"/>
+//         <xs:element name="legalstatus" type="legalstatus"/>
+//       </xs:choice>
+//     </xs:sequence>
+//     <xs:attributeGroup ref="am.common"/>
+//     <xs:attribute name="encodinganalog" type="xs:token"/>
+//     <xs:attribute name="localtype" type="xs:token"/>
+//   </xs:complexType>
+//
+// (accessrestrict and userestrict have the same structure.)
+//
+// EAD3 ships a <localtypedeclaration> element in <control> so each finding
+// aid can declare its own localtype conventions. There is no SAA- or
+// LoC-sanctioned master list.
+//
+// Note on mixed content: these elements can contain nested XML (<p>, <list>,
+// <chronlist>, nested <legalstatus>). We flatten to plain text for the
+// `text` field. Consumers needing the full mixed-content structure should
+// use CustomClassification with standard_id = "ead3" and the native XML
+// fragment in content.
+//
+// XSD source for the definitions:
+//   ead3.xsd lines 1136-1147 (legalstatus)
+//   ead3.xsd lines 1242-1253 (accessrestrict)
+//   ead3.xsd lines 1262-1273 (userestrict)
+// =============================================================================
+
+message EadClassification {
+  // <accessrestrict> — restrictions on who may access the materials.
+  optional AccessRestrict accessrestrict = 1;
+
+  // <userestrict> — restrictions on what may be done with the materials
+  // once access has been granted.
+  optional UseRestrict userestrict = 2;
+
+  // <legalstatus> — legal status of the materials.
+  // EAD3 does NOT define a controlled vocabulary for content here.
+  optional LegalStatus legalstatus = 3;
+
+  message AccessRestrict {
+    // EAD3 @localtype attribute — plain xs:token, institution-defined.
+    // EAD3 provides NO authority/vocabulary attribute system for this
+    // element — institutional conventions for @localtype are declared
+    // in <control>/<localtypedeclaration>, outside this element.
+    // Common values by community convention (NOT an EAD-mandated vocabulary):
+    // "privacy", "copyright", "classified", "donor", "ongoing research",
+    // "in process", "in preservation".
+    optional string localtype = 1;
+
+    // @encodinganalog (xs:token) — optional pointer to equivalent element
+    // in a related descriptive standard (MARC field, DC term).
+    optional string encodinganalog = 2;
+
+    // Flattened text content (m.blocks mixed content, plain-text rendering).
+    string text = 3;
+  }
+
+  message UseRestrict {
+    optional string localtype = 1;
+    optional string encodinganalog = 2;
+    string text = 3;
+  }
+
+  message LegalStatus {
+    // @localtype — plain xs:token, institution-defined (see AccessRestrict).
+    optional string localtype = 1;
+
+    // @encodinganalog.
+    optional string encodinganalog = 2;
+
+    // Flattened text content. Common values by community convention
+    // (NOT an EAD-mandated vocabulary): "copyrighted", "public domain",
+    // "public records", "orphan work", "copyright not evaluated",
+    // "copyright undetermined".
+    string text = 3;
+  }
+}

--- a/common/proto/ai/pipestream/data/v1/mods_access_condition.proto
+++ b/common/proto/ai/pipestream/data/v1/mods_access_condition.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "ModsAccessCondition";
+
+// =============================================================================
+// MODS (Metadata Object Description Schema)
+// =============================================================================
+//
+// MODS 3.7 — Library of Congress
+// http://www.loc.gov/standards/mods/
+// XSD: https://www.loc.gov/standards/mods/v3/mods-3-7.xsd
+//
+// Models only the <accessCondition> element of MODS. Other MODS top-level
+// elements (titleInfo, name, typeOfResource, originInfo, physicalDescription,
+// etc.) describe catalog records and are not classification metadata.
+//
+// MODS DOES NOT define a controlled vocabulary for accessCondition @type.
+// XSD source (mods-3-7.xsd lines 163-175):
+//
+//   <xs:element name="accessCondition" type="accessConditionDefinition"/>
+//   <xs:complexType name="accessConditionDefinition" mixed="true">
+//     <xs:complexContent mixed="true">
+//       <xs:extension base="extensionDefinition">
+//         <xs:attributeGroup ref="xlink:simpleLink"/>
+//         <xs:attributeGroup ref="languageAttributeGroup"/>
+//         <xs:attribute name="type" type="xs:string"/>
+//         <xs:attribute name="altRepGroup" type="xs:string"/>
+//         <xs:attributeGroup ref="altFormatAttributeGroup"/>
+//       </xs:extension>
+//     </xs:complexContent>
+//   </xs:complexType>
+//
+// The @type attribute is xs:string — unconstrained. The MODS User Guide
+// narrative lists four recommended values but the schema does not enforce
+// them. Also note: unlike MODS elements such as <subject> or <classification>,
+// <accessCondition> does NOT have @authority / @authorityURI attributes,
+// so there's no native vocabulary-pointer mechanism here.
+// =============================================================================
+
+message ModsClassification {
+  // MODS allows multiple <accessCondition> elements per record.
+  repeated AccessCondition access_conditions = 1;
+
+  message AccessCondition {
+    // <accessCondition> @type — plain xs:string per the MODS 3.7 XSD.
+    // The MODS User Guide recommends (but does not enforce) these values:
+    //   "restriction on access"
+    //   "use and reproduction"
+    //   "rights statement"
+    //   "license"
+    // Institutions may use any string. Other values are valid MODS.
+    optional string type = 1;
+
+    // Flattened text content of the element. MODS keeps this as mixed
+    // content with optional markup; we flatten to plain text.
+    string text = 2;
+
+    // @displayLabel — human-friendly label for UI display.
+    optional string display_label = 3;
+
+    // xlink:href — URI reference (often pointing to a rights statement URI).
+    optional string href = 4;
+  }
+}

--- a/common/proto/ai/pipestream/data/v1/mods_access_condition.proto
+++ b/common/proto/ai/pipestream/data/v1/mods_access_condition.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package ai.pipestream.data.v1;
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "ModsAccessCondition";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // MODS (Metadata Object Description Schema)

--- a/common/proto/ai/pipestream/data/v1/odrl_policy.proto
+++ b/common/proto/ai/pipestream/data/v1/odrl_policy.proto
@@ -1,0 +1,148 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "OdrlPolicy";
+
+// =============================================================================
+// ODRL (Open Digital Rights Language)
+// =============================================================================
+//
+// ODRL Information Model 2.2 — W3C Recommendation (2018-02-15)
+// https://www.w3.org/TR/odrl-model/
+// https://www.w3.org/TR/odrl-vocab/
+//
+// Models the ODRL policy shape: permissions, prohibitions, duties, each
+// bound to an action with optional constraints.
+//
+// ODRL IS FUNDAMENTALLY OPEN BY DESIGN. Per the ODRL Information Model
+// §3.3 (Profile Mechanism — NORMATIVE):
+//
+//   "Additional Actions for Rules: Create an instance of an Action and
+//    define its includedIn parent Action. The new Action MAY be defined
+//    as includedIn to any existing Action... ex:myAction a odrl:Action ."
+//
+// The same extensibility applies to Left Operands. Actions and Left Operands
+// in ODRL are identified by IRI; profiles can add new ones at will. There is
+// no formally closed set of actions in the ODRL Recommendation. The W3C
+// ODRL Vocabulary spec distinguishes:
+//
+//   - Core Vocabulary (§3.12): exactly 2 actions — `use` and `transferOwnership`
+//   - Common Vocabulary (§4.4): a recommended list of 49 additional actions
+//     that profiles MAY adopt. Non-normative.
+//
+// We therefore model action and left_operand as IRI strings (not enums),
+// matching ODRL's own native representation. Comments list the §4.4
+// recommended actions for documentation.
+//
+// Owned by this standard: the Operator enum. ODRL Operators are mathematical
+// comparison primitives and the 12-value set is closed in practice across all
+// known ODRL profiles. Modeled as a closed enum for ergonomics with an
+// OPERATOR_CUSTOM escape hatch for strict compliance with the profile mechanism.
+// =============================================================================
+
+message OdrlClassification {
+  // ODRL profile IRI. Canonical values:
+  //   http://www.w3.org/ns/odrl/2/core
+  //   http://www.w3.org/TR/odrl-vocab
+  // Custom profiles are expressed as their own IRIs.
+  optional string profile = 1;
+
+  // Permissions: what the assignee is allowed to do.
+  repeated Rule permissions = 2;
+
+  // Prohibitions: what the assignee is forbidden from doing. This is where
+  // most enforcement-relevant policy lives.
+  repeated Rule prohibitions = 3;
+
+  // Duties: what the assignee must do alongside their permitted actions.
+  repeated Rule duties = 4;
+
+  message Rule {
+    // Action IRI. See ODRL Vocabulary §3.12 (Core) and §4.4 (Common).
+    //
+    // Core Vocabulary (§3.12) — exactly 2 actions:
+    //   http://www.w3.org/ns/odrl/2/use
+    //   http://www.w3.org/ns/odrl/2/transferOwnership
+    //
+    // Common Vocabulary (§4.4) — 49 recommended actions, including:
+    //   acceptTracking, aggregate, annotate, anonymize, archive, attribute,
+    //   attribution, commercialUse, compensate, concurrentUse, delete,
+    //   derive, derivativeWorks, digitize, display, distribute, distribution,
+    //   ensureExclusivity, execute, extract, give, grantUse, include, index,
+    //   inform, install, modify, move, nextPolicy, notice, obtainConsent,
+    //   play, present, print, read, reproduce, reproduction, reviewPolicy,
+    //   sell, shareAlike, sharing, sourceCode, stream, synchronize,
+    //   textToSpeech, transform, translate, uninstall, watermark
+    //
+    // Profile-specific actions may be defined at any IRI. Consumers should
+    // match on the full IRI, not on the short localname.
+    string action = 1;
+
+    // Constraints on when the rule applies.
+    repeated Constraint constraints = 2;
+
+    // Party issuing the rule. Free-form IRI per ODRL.
+    optional string assigner = 3;
+
+    // Party the rule applies to. Free-form IRI per ODRL.
+    optional string assignee = 4;
+  }
+
+  message Constraint {
+    // Left operand IRI. See ODRL Vocabulary §4.5 (recommended Left Operands).
+    //
+    // The spec lists 32 recommended left operands including:
+    //   absoluteAssetPosition, absoluteSpatialAssetPosition,
+    //   absoluteTemporalAssetPosition, absoluteAssetSize, count, dateTime,
+    //   delayPeriod, deliveryChannel, elapsedTime, event, fileFormat,
+    //   industry, language, media, meteredTime, payAmount, percentage,
+    //   product, purpose, recipient, relativeAssetPosition,
+    //   relativeSpatialAssetPosition, relativeTemporalAssetPosition,
+    //   relativeAssetSize, resolution, spatial, spatialCoordinates,
+    //   systemDevice, timeInterval, unitOfCount, version, virtualLocation
+    //
+    // Profile-specific left operands may be defined at any IRI.
+    string left_operand = 1;
+
+    // Comparison operator. ODRL 2.2 defines 12 operators, modeled here as
+    // a closed enum. See Operator enum below.
+    Operator operator = 2;
+
+    // Right operand — what the left operand is compared against. The value
+    // type is determined by the left operand (e.g. ISO-8601 timestamp for
+    // dateTime, IRI for purpose, number for count). ODRL keeps this
+    // type-dependent on context.
+    string right_operand = 3;
+  }
+
+  // ODRL 2.2 comparison operators.
+  //
+  // Source: https://www.w3.org/TR/odrl-model/#constraint
+  //
+  // ODRL Information Model §3.16 defines exactly 12 constraint operators.
+  // In principle profiles may add new Operator instances via §3.3 extension,
+  // but in practice these 12 mathematical comparison primitives are semantically
+  // complete and no known ODRL profile has extended them.
+  enum Operator {
+    OPERATOR_UNSPECIFIED = 0;
+    OPERATOR_EQ = 1;          // equal to
+    OPERATOR_NEQ = 2;         // not equal to
+    OPERATOR_LT = 3;          // less than
+    OPERATOR_GT = 4;          // greater than
+    OPERATOR_LTEQ = 5;        // less than or equal to
+    OPERATOR_GTEQ = 6;        // greater than or equal to
+    OPERATOR_IS_A = 7;        // is an instance of a class
+    OPERATOR_HAS_PART = 8;    // has as a part
+    OPERATOR_IS_PART_OF = 9;  // is a part of
+    OPERATOR_IS_ALL_OF = 10;  // matches all of
+    OPERATOR_IS_ANY_OF = 11;  // matches any of
+    OPERATOR_IS_NONE_OF = 12; // matches none of
+
+    // Escape hatch for profile-defined operators (ODRL §3.3 extension).
+    // Rarely used in practice; included for strict ODRL compliance.
+    OPERATOR_CUSTOM = 100;
+  }
+}

--- a/common/proto/ai/pipestream/data/v1/odrl_policy.proto
+++ b/common/proto/ai/pipestream/data/v1/odrl_policy.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package ai.pipestream.data.v1;
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "OdrlPolicy";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // ODRL (Open Digital Rights Language)
@@ -128,17 +128,17 @@ message OdrlClassification {
   // complete and no known ODRL profile has extended them.
   enum Operator {
     OPERATOR_UNSPECIFIED = 0;
-    OPERATOR_EQ = 1;          // equal to
-    OPERATOR_NEQ = 2;         // not equal to
-    OPERATOR_LT = 3;          // less than
-    OPERATOR_GT = 4;          // greater than
-    OPERATOR_LTEQ = 5;        // less than or equal to
-    OPERATOR_GTEQ = 6;        // greater than or equal to
-    OPERATOR_IS_A = 7;        // is an instance of a class
-    OPERATOR_HAS_PART = 8;    // has as a part
-    OPERATOR_IS_PART_OF = 9;  // is a part of
-    OPERATOR_IS_ALL_OF = 10;  // matches all of
-    OPERATOR_IS_ANY_OF = 11;  // matches any of
+    OPERATOR_EQ = 1; // equal to
+    OPERATOR_NEQ = 2; // not equal to
+    OPERATOR_LT = 3; // less than
+    OPERATOR_GT = 4; // greater than
+    OPERATOR_LTEQ = 5; // less than or equal to
+    OPERATOR_GTEQ = 6; // greater than or equal to
+    OPERATOR_IS_A = 7; // is an instance of a class
+    OPERATOR_HAS_PART = 8; // has as a part
+    OPERATOR_IS_PART_OF = 9; // is a part of
+    OPERATOR_IS_ALL_OF = 10; // matches all of
+    OPERATOR_IS_ANY_OF = 11; // matches any of
     OPERATOR_IS_NONE_OF = 12; // matches none of
 
     // Escape hatch for profile-defined operators (ODRL §3.3 extension).

--- a/common/proto/ai/pipestream/data/v1/pipeline_core_types.proto
+++ b/common/proto/ai/pipestream/data/v1/pipeline_core_types.proto
@@ -199,6 +199,11 @@ message SearchMetadata {
   // One entry per unique chunking group — computed once from the full source text
   // before chunking, then shared across all embedder results that use those chunks.
   repeated SourceFieldAnalytics source_field_analytics = 26;
+
+  // Quality assessment result. Populated by the quality-checker module,
+  // which runs LAST — after parser, chunker, embedder, semantic processing.
+  // See QualityIndex definition below.
+  optional QualityIndex quality_index = 27;
 }
 
 // Collection of keywords extracted from a document.
@@ -790,22 +795,107 @@ message ChunkEmbedding {
   optional string chunk_config_id = 7;
 }
 
-// Metadata for centroid (averaged) vector result sets.
+// =============================================================================
+// Granularity & Pooling — vocabulary for semantic vector result sets
+// =============================================================================
+//
+// Every SemanticProcessingResult belongs to one GranularityLevel (the "size"
+// of text each vector represents) and one PoolingMethod (how the vector was
+// produced from text — directly embedded or pooled from child vectors).
+// These axes are orthogonal: a SECTION-granularity result could in principle
+// be direct-embedded (unusual, limited by model context) or pooled from
+// paragraph/chunk vectors (common).
+//
+// Consumers that filter "give me document-level vectors" or "give me sentence
+// vectors only" should match on GranularityLevel, NOT parse config ID strings.
+
+// Size of text each vector in a SemanticProcessingResult represents.
+enum GranularityLevel {
+  GRANULARITY_LEVEL_UNSPECIFIED = 0;
+  // Primary semantic chunker output — size varies by topic boundaries.
+  // Produced by CHUNK_ALGORITHM_SEMANTIC.
+  GRANULARITY_LEVEL_SEMANTIC_CHUNK = 1;
+  // One vector per sentence. Produced by CHUNK_ALGORITHM_SENTENCE or by the
+  // sentence detection pass inside semantic chunking.
+  GRANULARITY_LEVEL_SENTENCE = 2;
+  // Paragraph-level vectors. Typically pooled from sentences.
+  GRANULARITY_LEVEL_PARAGRAPH = 3;
+  // Section-level vectors. Typically pooled from paragraphs or chunks using
+  // DocOutline.Section boundaries.
+  GRANULARITY_LEVEL_SECTION = 4;
+  // Single vector for the entire document. Typically pooled from sections
+  // or paragraphs.
+  GRANULARITY_LEVEL_DOCUMENT = 5;
+}
+
+// How vectors in a SemanticProcessingResult were produced from text.
+enum PoolingMethod {
+  POOLING_METHOD_UNSPECIFIED = 0;
+  // Directly embedded by an embedding model — no pooling.
+  POOLING_METHOD_DIRECT = 1;
+  // Arithmetic mean of child vectors.
+  POOLING_METHOD_MEAN = 2;
+  // Weighted mean of child vectors, typically weighted by chunk length
+  // (character or word count).
+  POOLING_METHOD_WEIGHTED_MEAN = 3;
+}
+
+// Metadata for centroid (pooled) vector result sets.
 // Present when a SemanticProcessingResult contains computed centroids
 // rather than direct embeddings from an embedding model.
 message CentroidMetadata {
-  // Granularity level of this centroid.
-  // Values: "sentence", "paragraph_centroid", "section_centroid", "document_centroid"
-  string granularity = 1;
+  // Granularity level of this centroid. Typically PARAGRAPH, SECTION, or
+  // DOCUMENT (SEMANTIC_CHUNK and SENTENCE are usually directly embedded).
+  GranularityLevel granularity = 1;
 
-  // How many source vectors were averaged to produce this centroid.
+  // How many source vectors were averaged/pooled to produce this centroid.
   int32 source_vector_count = 2;
 
-  // Section title (for section_centroid granularity, from DocOutline).
+  // Section title (for GRANULARITY_LEVEL_SECTION, from DocOutline.Section.title).
   optional string section_title = 3;
 
-  // Section heading depth (for section_centroid granularity).
+  // Section heading depth (for GRANULARITY_LEVEL_SECTION, from DocOutline.Section.depth).
   optional int32 section_depth = 4;
+}
+
+// Traceability metadata for a SemanticChunk — where in the document it came
+// from, which parser produced the source text, what was pooled (for centroid
+// chunks), and any temporal range (for audio/video transcript chunks).
+//
+// This is the cross-link between a chunk and the structural metadata that
+// already lives elsewhere on PipeDoc:
+//   - DocOutline.Section for section/heading context (via section_id)
+//   - ParsedMetadata for parser attribution (via parser_name)
+//   - Sibling SemanticChunk IDs for pooled-centroid lineage
+//
+// Character-level provenance (start/end offset in the source text) already
+// lives on ChunkEmbedding.original_char_start_offset / end_offset and is
+// intentionally NOT duplicated here.
+message ChunkProvenance {
+  // Reference to Section.id in PipeDoc.search_metadata.doc_outline. Consumers
+  // can resolve page_start/page_end/char offsets via the Section.
+  optional string section_id = 1;
+
+  // Pre-computed heading breadcrumb for UI display and quality heuristics.
+  // Example: "Chapter 3 > Section 3.2 > Methodology"
+  optional string heading_breadcrumb = 2;
+
+  // Parser that produced the source text this chunk was derived from.
+  // Values: "tika", "docling", "html-raw", etc.
+  optional string parser_name = 3;
+
+  // For pooled/centroid chunks: the chunk_ids of the child chunks that were
+  // averaged or grouped. Empty for directly-embedded chunks.
+  //
+  // Also populated by DOCLING chunking with group_small_chunks=true, where
+  // the group's source_chunk_ids point back to the original Docling cells
+  // that were aggregated into this grouped chunk.
+  repeated string source_chunk_ids = 4;
+
+  // Temporal range for audio/video transcript chunks (seconds from start
+  // of the media). Zero for non-temporal chunks.
+  optional float start_seconds = 5;
+  optional float end_seconds = 6;
 }
 
 // Single semantic chunk with its text and embedding.
@@ -820,6 +910,9 @@ message SemanticChunk {
   map<string, google.protobuf.Value> metadata = 4;
   // NLP-derived analytics for this chunk's text content.
   optional ChunkAnalytics chunk_analytics = 5;
+  // Provenance: where this chunk came from in the original document, what
+  // was pooled (for centroid chunks), temporal range (for audio/video).
+  optional ChunkProvenance provenance = 6;
 }
 
 // Complete result of semantic chunking and embedding process.
@@ -862,9 +955,21 @@ message SemanticProcessingResult {
 
   // Semantic config reference — present when this result was produced by semantic chunking.
   optional string semantic_config_id = 10;
-  // Granularity of this result set (semantic path only).
-  // Uses string values: SEMANTIC_CHUNK, SENTENCE, PARAGRAPH, SECTION, DOCUMENT
-  optional string semantic_granularity = 11;
+
+  // Granularity level of vectors in this result set.
+  // Consumers that filter by granularity (e.g. "give me document vectors")
+  // should match on this enum rather than parsing chunk_config_id strings.
+  optional GranularityLevel granularity = 11;
+
+  // How the vectors in this result set were produced — direct embedding vs
+  // pooled from finer-grained vectors.
+  optional PoolingMethod pooling_method = 12;
+
+  // If this result set was pooled from another, the result_id of the
+  // finer-grained source. Enables hierarchy traversal:
+  //   document-centroid → section-centroid → paragraph-centroid → sentence
+  // Empty for directly-embedded result sets.
+  optional string parent_result_id = 13;
 }
 
 // Source of a log entry — distinguishes engine routing logs from module processing logs.
@@ -1290,4 +1395,93 @@ message SentenceSpan {
   string text = 1;
   int32 start_offset = 2;
   int32 end_offset = 3;
+}
+
+// =============================================================================
+// Quality Index — Document quality assessment results
+// =============================================================================
+//
+// Produced by the quality-checker module, which runs LAST in the pipeline
+// (after parser, chunker, embedder, semantic processing). Individual quality
+// dimensions are scored by pluggable QualityChecker implementations; the
+// composite score is computed per the active QualityProfile's composite_method.
+//
+// Storage: the OpenSearch sink flattens QualityIndex into searchable fields:
+//   quality_composite, quality_profile_id, quality_<dim>, quality_<dim>_weight
+// so every dimension is individually filterable, sortable, facetable, and
+// boostable at search time.
+//
+// Profile configuration (QualityProfile, QualityDimensionConfig) lives in the
+// quality/ bufmodule (ai.pipestream.quality.v1) — those are service-config
+// types, not runtime pipeline types.
+
+// Quality assessment result for a document. One per PipeDoc.
+message QualityIndex {
+  // Overall composite score (0.0 - 1.0).
+  float composite_score = 1;
+
+  // How the composite was computed from individual dimension scores.
+  CompositeMethod composite_method = 2;
+
+  // Profile that was used for this assessment. References
+  // QualityProfile.profile_id in the quality registry.
+  string profile_id = 3;
+
+  // Profile version at assessment time. Preserved so that later edits to
+  // the profile don't invalidate historical assessments — you can always
+  // tell which version of the profile scored any given document.
+  optional string profile_version = 4;
+
+  // Individual dimension scores (one per enabled dimension in the profile).
+  repeated QualityDimension dimensions = 5;
+
+  // When this assessment was computed.
+  google.protobuf.Timestamp assessed_at = 6;
+
+  // How the composite score is computed from individual dimension scores.
+  enum CompositeMethod {
+    COMPOSITE_METHOD_UNSPECIFIED = 0;
+    // Weighted arithmetic mean of dimension scores using their weights.
+    COMPOSITE_METHOD_WEIGHTED_MEAN = 1;
+    // Harmonic mean — penalizes low scores heavily.
+    COMPOSITE_METHOD_HARMONIC_MEAN = 2;
+    // Geometric mean — balanced penalty for low scores.
+    COMPOSITE_METHOD_GEOMETRIC_MEAN = 3;
+    // Minimum score across dimensions — the composite is only as good as
+    // the worst dimension. Harshest method.
+    COMPOSITE_METHOD_MIN = 4;
+  }
+}
+
+// A single dimension's contribution to the composite quality score.
+// Preserves the weight that was applied AT ASSESSMENT TIME so reproducibility
+// survives later edits to the profile weights.
+message QualityDimension {
+  // Dimension identifier, matches QualityChecker.dimensionId().
+  // Built-in dimensions include:
+  //   "recency", "readability", "completeness", "topic_relevance",
+  //   "information_density", "authority", "extraction_quality", "duplication"
+  // Custom dimensions may be added by pluggable QualityChecker CDI beans.
+  string dimension_id = 1;
+
+  // Score for this dimension (0.0 - 1.0).
+  float score = 2;
+
+  // Weight applied in the composite calculation (0.0 - 1.0).
+  // Snapshot of the profile's weight at assessment time.
+  float weight = 3;
+
+  // Confidence in the score (0.0 - 1.0). Dimensions with low confidence
+  // may be excluded from the composite or surfaced separately in the UI.
+  optional float confidence = 4;
+
+  // Short human-readable explanation for UI/debug display. Keep under
+  // ~120 chars to avoid bloating every indexed document.
+  // Example: "Published 14 days ago, half-life 365 days → 0.97"
+  optional string explanation = 5;
+
+  // Dimension-specific structured metadata.
+  // Example for "recency": {"age_days": "14", "half_life_days": "365"}
+  // Example for "duplication": {"match_doc_id": "abc123", "similarity": "0.97"}
+  map<string, string> metadata = 6;
 }

--- a/common/proto/ai/pipestream/data/v1/premis_rights.proto
+++ b/common/proto/ai/pipestream/data/v1/premis_rights.proto
@@ -5,8 +5,8 @@ package ai.pipestream.data.v1;
 import "google/protobuf/timestamp.proto";
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "PremisRights";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // PREMIS Rights Statement

--- a/common/proto/ai/pipestream/data/v1/premis_rights.proto
+++ b/common/proto/ai/pipestream/data/v1/premis_rights.proto
@@ -1,0 +1,163 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+import "google/protobuf/timestamp.proto";
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "PremisRights";
+
+// =============================================================================
+// PREMIS Rights Statement
+// =============================================================================
+//
+// PREMIS Data Dictionary for Preservation Metadata — Library of Congress
+// https://www.loc.gov/standards/premis/
+// XSD: https://www.loc.gov/standards/premis/v3/premis-v3-0.xsd
+//
+// Models the PREMIS Rights entity (rightsStatementComplexType in the XSD),
+// which represents rights statements attached to preservation objects.
+// Other PREMIS entities (Object, Event, Agent, Environment) are out of
+// scope for this classification model.
+//
+// PREMIS DOES NOT prescribe controlled vocabularies for most fields.
+// Per the Data Dictionary (v2.2 §"Data constraint", p.22):
+//
+//   "The preservation repository should establish an authority list of
+//    values that are useful and meaningful to the repository. The PREMIS
+//    Data Dictionary does not specify what this authority list should be,
+//    and it is assumed that different repositories will use different
+//    vocabularies."
+//
+// PREMIS 3.0 XSD models these fields as `stringPlusAuthority`:
+//
+//   <xs:complexType name="stringPlusAuthority">
+//     <xs:simpleContent>
+//       <xs:extension base="xs:string">
+//         <xs:attributeGroup ref="authorityAttributeGroup"/>
+//       </xs:extension>
+//     </xs:simpleContent>
+//   </xs:complexType>
+//
+//   <xs:attributeGroup name="authorityAttributeGroup">
+//     <xs:attribute name="authority" type="xs:string"/>
+//     <xs:attribute name="authorityURI" type="xs:anyURI"/>
+//     <xs:attribute name="valueURI" type="xs:anyURI"/>
+//   </xs:attributeGroup>
+//
+// We faithfully mirror this pattern via the PremisStringPlusAuthority
+// message below. The string value carries the term; the optional authority
+// fields record which controlled vocabulary the value was drawn from.
+// This matches what PREMIS actually says: "bring your own vocabulary,
+// tell us which one you used."
+// =============================================================================
+
+// Exact mirror of the PREMIS 3.0 stringPlusAuthority XSD type. Prefixed
+// with "Premis" because the pattern is owned by PREMIS — other standards
+// in this package handle extensibility differently (EAD3 uses plain xs:token
+// @localtype, MODS uses plain xs:string @type, ODRL uses IRI strings with
+// profile-based extension). This type is used ONLY by PremisClassification.
+//
+// Used by PremisClassification for: rightsBasis, rightsGranted.act,
+// restriction — all three are stringPlusAuthority in the PREMIS XSD.
+//
+// XSD source (premis-v3-0.xsd lines 1206-1220):
+//   <xs:complexType name="stringPlusAuthority">
+//     <xs:simpleContent>
+//       <xs:extension base="xs:string">
+//         <xs:attributeGroup ref="authorityAttributeGroup"/>
+//       </xs:extension>
+//     </xs:simpleContent>
+//   </xs:complexType>
+//
+//   <xs:attributeGroup name="authorityAttributeGroup">
+//     <xs:attribute name="authority" type="xs:string"/>
+//     <xs:attribute name="authorityURI" type="xs:anyURI"/>
+//     <xs:attribute name="valueURI" type="xs:anyURI"/>
+//   </xs:attributeGroup>
+message PremisStringPlusAuthority {
+  // The value itself. Free-form per PREMIS.
+  string value = 1;
+
+  // Name of the controlled vocabulary this value was drawn from.
+  // Examples: "actionsGranted", "rightsBasis", "copyrightStatus",
+  // "archivematica-rights-actions", "local-repo-v1".
+  optional string authority = 2;
+
+  // URI of the controlled vocabulary.
+  // Example: "http://id.loc.gov/vocabulary/preservation/actionsGranted"
+  optional string authority_uri = 3;
+
+  // URI of the specific term within the vocabulary.
+  // Example: "http://id.loc.gov/vocabulary/preservation/actionsGranted/mig"
+  optional string value_uri = 4;
+}
+
+// PREMIS Rights Statement — mirrors rightsStatementComplexType in the XSD.
+message PremisClassification {
+  // rightsStatementIdentifier — repository-scoped unique ID.
+  // Free-form because institutional ID schemes vary.
+  string rights_statement_identifier = 1;
+
+  // rightsBasis — why these rights exist.
+  //
+  // PREMIS 3.0 XSD type: stringPlusAuthority (NOT a closed enum).
+  // Common values from the PREMIS Data Dictionary examples:
+  //   "copyright", "license", "statute", "institutional policy", "other"
+  // Repositories may define additional values (e.g. "donor" in
+  // Archivematica) and record the vocabulary via the authority attributes.
+  PremisStringPlusAuthority basis = 2;
+
+  // rightsGranted — one or more permissions granted, each with an act,
+  // optional restrictions, and optional terms.
+  // XSD: minOccurs="0" maxOccurs="unbounded"
+  repeated RightsGranted rights_granted = 3;
+
+  // Reference (URI or external ID) to supporting documentation for the
+  // rights statement (e.g. a signed license document).
+  optional string rights_documentation_ref = 4;
+
+  // A single rightsGranted sub-statement — mirrors rightsGrantedComplexType
+  // in the XSD.
+  message RightsGranted {
+    // act — the action being granted or restricted.
+    //
+    // PREMIS 3.0 XSD type: stringPlusAuthority (NOT a closed enum).
+    // The PREMIS Data Dictionary does NOT prescribe a controlled vocabulary
+    // for this field. LoC maintained a deprecated 6-value scheme called
+    // "actionsGranted" (delete, disseminate, migrate, modify, replicate, use)
+    // at id.loc.gov/vocabulary/preservation/actionsGranted (deprecated
+    // 2018-09-24). Repositories are expected to bring their own vocabulary
+    // and record it via the authority attributes.
+    //
+    // Examples:
+    //   value="migrate" authority="actionsGranted"
+    //     authorityURI="http://id.loc.gov/vocabulary/preservation/actionsGranted"
+    //     valueURI="http://id.loc.gov/vocabulary/preservation/actionsGranted/mig"
+    //
+    //   value="ingest" authority="archivematica"
+    //
+    //   value="crawl" authority="pipestream-preservation-v1"
+    PremisStringPlusAuthority act = 1;
+
+    // restriction — constraints on the act. Repeatable.
+    // PREMIS 3.0 XSD type: stringPlusAuthority (free text or from a
+    // local controlled vocabulary, recorded via authority attributes).
+    repeated PremisStringPlusAuthority restriction = 2;
+
+    // termOfGrant — start and optional end date for the grant period.
+    // XSD: startAndEndDateComplexType (startDate required, endDate optional).
+    optional google.protobuf.Timestamp term_of_grant_start = 3;
+    optional google.protobuf.Timestamp term_of_grant_end = 4;
+
+    // termOfRestriction — start and optional end date for the restriction.
+    // XSD: startAndEndDateComplexType.
+    optional google.protobuf.Timestamp term_of_restriction_start = 5;
+    optional google.protobuf.Timestamp term_of_restriction_end = 6;
+
+    // rightsGrantedNote — repeatable free-text note.
+    // XSD: xs:string, minOccurs="0" maxOccurs="unbounded"
+    repeated string note = 7;
+  }
+}

--- a/common/proto/ai/pipestream/data/v1/rights_statements.proto
+++ b/common/proto/ai/pipestream/data/v1/rights_statements.proto
@@ -3,8 +3,8 @@ syntax = "proto3";
 package ai.pipestream.data.v1;
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.data.v1";
 option java_outer_classname = "RightsStatements";
+option java_package = "ai.pipestream.data.v1";
 
 // =============================================================================
 // RightsStatements.org
@@ -29,21 +29,21 @@ message RightsStatementsClassification {
     STATEMENT_UNSPECIFIED = 0;
 
     // "In Copyright" family
-    STATEMENT_IN_COPYRIGHT = 1;                               // /InC/1.0/
-    STATEMENT_IN_COPYRIGHT_EDU = 2;                           // /InC-EDU/1.0/
-    STATEMENT_IN_COPYRIGHT_NON_COMMERCIAL = 3;                // /InC-NC/1.0/
-    STATEMENT_IN_COPYRIGHT_RIGHTS_HOLDER_UNLOCATABLE = 4;     // /InC-RUU/1.0/
-    STATEMENT_IN_COPYRIGHT_EU_ORPHAN_WORK = 5;                // /InC-OW-EU/1.0/
+    STATEMENT_IN_COPYRIGHT = 1; // /InC/1.0/
+    STATEMENT_IN_COPYRIGHT_EDU = 2; // /InC-EDU/1.0/
+    STATEMENT_IN_COPYRIGHT_NON_COMMERCIAL = 3; // /InC-NC/1.0/
+    STATEMENT_IN_COPYRIGHT_RIGHTS_HOLDER_UNLOCATABLE = 4; // /InC-RUU/1.0/
+    STATEMENT_IN_COPYRIGHT_EU_ORPHAN_WORK = 5; // /InC-OW-EU/1.0/
 
     // "No Copyright" family
-    STATEMENT_NO_COPYRIGHT_CONTRACTUAL_RESTRICTIONS = 6;      // /NoC-CR/1.0/
-    STATEMENT_NO_COPYRIGHT_NON_COMMERCIAL = 7;                // /NoC-NC/1.0/
-    STATEMENT_NO_COPYRIGHT_OTHER_KNOWN_LEGAL = 8;             // /NoC-OKLR/1.0/
-    STATEMENT_NO_COPYRIGHT_UNITED_STATES = 9;                 // /NoC-US/1.0/
+    STATEMENT_NO_COPYRIGHT_CONTRACTUAL_RESTRICTIONS = 6; // /NoC-CR/1.0/
+    STATEMENT_NO_COPYRIGHT_NON_COMMERCIAL = 7; // /NoC-NC/1.0/
+    STATEMENT_NO_COPYRIGHT_OTHER_KNOWN_LEGAL = 8; // /NoC-OKLR/1.0/
+    STATEMENT_NO_COPYRIGHT_UNITED_STATES = 9; // /NoC-US/1.0/
 
     // "Other" family
-    STATEMENT_COPYRIGHT_NOT_EVALUATED = 10;                   // /CNE/1.0/
-    STATEMENT_COPYRIGHT_UNDETERMINED = 11;                    // /UND/1.0/
-    STATEMENT_NO_KNOWN_COPYRIGHT = 12;                        // /NKC/1.0/
+    STATEMENT_COPYRIGHT_NOT_EVALUATED = 10; // /CNE/1.0/
+    STATEMENT_COPYRIGHT_UNDETERMINED = 11; // /UND/1.0/
+    STATEMENT_NO_KNOWN_COPYRIGHT = 12; // /NKC/1.0/
   }
 }

--- a/common/proto/ai/pipestream/data/v1/rights_statements.proto
+++ b/common/proto/ai/pipestream/data/v1/rights_statements.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package ai.pipestream.data.v1;
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.data.v1";
+option java_outer_classname = "RightsStatements";
+
+// =============================================================================
+// RightsStatements.org
+// =============================================================================
+//
+// RightsStatements.org 1.0 — joint DPLA / Europeana vocabulary.
+// https://rightsstatements.org/
+//
+// A canonical set of 12 statements designed for cultural heritage items.
+// Fully enumerated; no escape hatch needed because the vocabulary is closed
+// by design — new statements require a versioned release of the vocabulary.
+//
+// Owned by this standard: the Statement enum (all 12 canonical values).
+// =============================================================================
+
+message RightsStatementsClassification {
+  Statement statement = 1;
+
+  // The 12 RightsStatements.org 1.0 canonical statements.
+  // Each value corresponds to a stable URI under https://rightsstatements.org/vocab/
+  enum Statement {
+    STATEMENT_UNSPECIFIED = 0;
+
+    // "In Copyright" family
+    STATEMENT_IN_COPYRIGHT = 1;                               // /InC/1.0/
+    STATEMENT_IN_COPYRIGHT_EDU = 2;                           // /InC-EDU/1.0/
+    STATEMENT_IN_COPYRIGHT_NON_COMMERCIAL = 3;                // /InC-NC/1.0/
+    STATEMENT_IN_COPYRIGHT_RIGHTS_HOLDER_UNLOCATABLE = 4;     // /InC-RUU/1.0/
+    STATEMENT_IN_COPYRIGHT_EU_ORPHAN_WORK = 5;                // /InC-OW-EU/1.0/
+
+    // "No Copyright" family
+    STATEMENT_NO_COPYRIGHT_CONTRACTUAL_RESTRICTIONS = 6;      // /NoC-CR/1.0/
+    STATEMENT_NO_COPYRIGHT_NON_COMMERCIAL = 7;                // /NoC-NC/1.0/
+    STATEMENT_NO_COPYRIGHT_OTHER_KNOWN_LEGAL = 8;             // /NoC-OKLR/1.0/
+    STATEMENT_NO_COPYRIGHT_UNITED_STATES = 9;                 // /NoC-US/1.0/
+
+    // "Other" family
+    STATEMENT_COPYRIGHT_NOT_EVALUATED = 10;                   // /CNE/1.0/
+    STATEMENT_COPYRIGHT_UNDETERMINED = 11;                    // /UND/1.0/
+    STATEMENT_NO_KNOWN_COPYRIGHT = 12;                        // /NKC/1.0/
+  }
+}

--- a/opensearch/proto/ai/pipestream/opensearch/v1/opensearch_document.proto
+++ b/opensearch/proto/ai/pipestream/opensearch/v1/opensearch_document.proto
@@ -84,16 +84,9 @@ message SemanticVectorSet {
   // Semantic path: references a pre-registered semantic config.
   optional string semantic_config_id = 7;
   // Granularity of vectors in this set (semantic path only).
-  optional SemanticGranularity granularity = 8;
-}
-
-enum SemanticGranularity {
-  SEMANTIC_GRANULARITY_UNSPECIFIED = 0;
-  SEMANTIC_GRANULARITY_SEMANTIC_CHUNK = 1;
-  SEMANTIC_GRANULARITY_SENTENCE = 2;
-  SEMANTIC_GRANULARITY_PARAGRAPH = 3;
-  SEMANTIC_GRANULARITY_SECTION = 4;
-  SEMANTIC_GRANULARITY_DOCUMENT = 5;
+  // Shared vocabulary with SemanticProcessingResult.granularity and
+  // CentroidMetadata.granularity — defined in common/pipeline_core_types.proto.
+  optional ai.pipestream.data.v1.GranularityLevel granularity = 8;
 }
 
 // Strategy for how document embeddings are physically stored in OpenSearch.

--- a/opensearch/proto/ai/pipestream/opensearch/v1/vector_set.proto
+++ b/opensearch/proto/ai/pipestream/opensearch/v1/vector_set.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package ai.pipestream.opensearch.v1;
 
-import "ai/pipestream/opensearch/v1/opensearch_document.proto";
+import "ai/pipestream/data/v1/pipeline_core_types.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -125,7 +125,7 @@ message VectorSet {
   // Semantic path: FK to SemanticConfig. Null for standard chunking VectorSets.
   optional string semantic_config_id = 18;
   // Granularity within a semantic config family.
-  optional SemanticGranularity granularity = 19;
+  optional ai.pipestream.data.v1.GranularityLevel granularity = 19;
 }
 
 // === Create ===
@@ -167,7 +167,7 @@ message CreateVectorSetRequest {
 
   optional string content_signature = 14;
   optional string semantic_config_id = 15;
-  optional SemanticGranularity granularity = 16;
+  optional ai.pipestream.data.v1.GranularityLevel granularity = 16;
 }
 
 message CreateVectorSetResponse {

--- a/quality/buf.yaml
+++ b/quality/buf.yaml
@@ -1,0 +1,13 @@
+version: v2
+modules:
+  - path: proto
+    name: buf.build/pipestreamai/quality
+deps:
+  - buf.build/grpc/grpc
+  - buf.build/googleapis/googleapis
+lint:
+  use:
+    - STANDARD
+breaking:
+  use:
+    - FILE

--- a/quality/proto/ai/pipestream/quality/v1/quality_assessment.proto
+++ b/quality/proto/ai/pipestream/quality/v1/quality_assessment.proto
@@ -6,8 +6,8 @@ import "ai/pipestream/data/v1/pipeline_core_types.proto";
 import "ai/pipestream/quality/v1/quality_profile.proto";
 
 option java_multiple_files = true;
-option java_package = "ai.pipestream.quality.v1";
 option java_outer_classname = "QualityAssessment";
+option java_package = "ai.pipestream.quality.v1";
 
 // =============================================================================
 // QualityAssessmentService — standalone quality assessment entry point

--- a/quality/proto/ai/pipestream/quality/v1/quality_assessment.proto
+++ b/quality/proto/ai/pipestream/quality/v1/quality_assessment.proto
@@ -1,0 +1,137 @@
+syntax = "proto3";
+
+package ai.pipestream.quality.v1;
+
+import "ai/pipestream/data/v1/pipeline_core_types.proto";
+import "ai/pipestream/quality/v1/quality_profile.proto";
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.quality.v1";
+option java_outer_classname = "QualityAssessment";
+
+// =============================================================================
+// QualityAssessmentService — standalone quality assessment entry point
+// =============================================================================
+//
+// This service exposes the quality assessor as a first-class gRPC endpoint,
+// independent of the pipeline. The quality pipeline module (which implements
+// PipeStepProcessorService.ProcessData) delegates to the same underlying
+// QualityAssessor CDI bean as this service — one code path, two entry points.
+//
+// Use cases:
+//   - External re-scoring of already-indexed documents without re-running
+//     the whole pipeline
+//   - Testing — module-testing-sidecar can call Assess directly with a
+//     synthetic PipeDoc, no pipeline required
+//   - Ad-hoc dashboards and quality audits
+//   - Dry-run scoring to compare profiles before rolling out a change
+service QualityAssessmentService {
+  // Assess quality for a document. Reads the document's search_metadata,
+  // parsed_metadata, and ownership context; runs the resolved QualityProfile's
+  // enabled dimensions; returns a QualityIndex.
+  //
+  // If dry_run is false (default), the returned updated_document has its
+  // search_metadata.quality_index field set. If dry_run is true, the caller
+  // gets only the QualityIndex in the response and the document is not
+  // mutated.
+  rpc Assess(AssessRequest) returns (AssessResponse);
+
+  // Return the list of QualityChecker dimension IDs registered on this
+  // server, with their required inputs and JSON config schemas. Used by
+  // QualityProfileService to validate dimension IDs at create/update time,
+  // and by UIs to build profile editors.
+  rpc ListAvailableDimensions(ListAvailableDimensionsRequest) returns (ListAvailableDimensionsResponse);
+}
+
+// =============================================================================
+// Assess RPC messages
+// =============================================================================
+
+message AssessRequest {
+  // Document to assess. Must carry SearchMetadata populated by earlier
+  // pipeline stages (parser, chunker, embedder). The assessor reads:
+  //   - document.search_metadata.* (base fields, semantic_results, etc.)
+  //   - document.parsed_metadata[] (Tika, Docling, etc.)
+  //   - document.ownership (for profile resolution)
+  ai.pipestream.data.v1.PipeDoc document = 1;
+
+  // Which QualityProfile to apply. If omitted, the server resolves the
+  // profile using the standard priority:
+  //   document.ownership.datasource_id → account_id → default
+  optional string profile_id = 2;
+
+  // When true, the assessor runs but does NOT mutate the input document.
+  // Only the QualityIndex is returned in the response. Default: false.
+  bool dry_run = 3;
+
+  // Optional subset of dimension IDs to run. When set, overrides the
+  // profile's enabled dimensions — only the listed dimensions are evaluated.
+  // Empty = run all enabled dimensions from the resolved profile.
+  // Useful for incremental scoring ("just recompute topic_relevance").
+  repeated string dimension_ids_filter = 4;
+}
+
+message AssessResponse {
+  // The quality assessment result.
+  ai.pipestream.data.v1.QualityIndex index = 1;
+
+  // The updated document with quality_index populated on search_metadata.
+  // Only set when the request had dry_run=false.
+  optional ai.pipestream.data.v1.PipeDoc updated_document = 2;
+
+  // If any required dimensions failed or the profile could not be resolved,
+  // structured error info. Non-required dimension failures are recorded
+  // inside the QualityIndex as missing dimensions and do NOT populate this
+  // field — this field is reserved for hard failures that invalidate the
+  // whole assessment.
+  optional ai.pipestream.data.v1.ErrorData error = 3;
+
+  // Which profile was actually used, after resolution. Useful when the
+  // caller left profile_id unset and wants to know which tenant profile
+  // the server picked.
+  string resolved_profile_id = 4;
+
+  // Dimensions that were skipped because their required inputs were not
+  // available on the document (e.g. topic_relevance skipped because no
+  // document vector exists yet). Informational — this is NOT an error.
+  repeated string skipped_dimensions = 5;
+}
+
+// =============================================================================
+// ListAvailableDimensions RPC messages
+// =============================================================================
+
+message ListAvailableDimensionsRequest {}
+
+message ListAvailableDimensionsResponse {
+  repeated DimensionDescriptor dimensions = 1;
+
+  message DimensionDescriptor {
+    // Dimension ID, matches QualityChecker.dimensionId() and the string used
+    // in QualityDimensionConfig.dimension_id.
+    string dimension_id = 1;
+
+    // Human-readable display name for UI.
+    string display_name = 2;
+
+    // Short description of what this dimension measures.
+    string description = 3;
+
+    // Which inputs this checker requires. The assessor uses this to skip
+    // the checker when its inputs aren't available on a given document.
+    repeated QualityInput required_inputs = 4;
+
+    // JSON schema for the dimension-specific config that goes in
+    // QualityDimensionConfig.config. UI form generators (JSONForms etc.)
+    // use this to build the per-dimension editor.
+    optional string config_schema = 5;
+
+    // Whether this dimension is provided by a built-in checker or a
+    // user-supplied CDI bean. Informational only.
+    bool is_builtin = 6;
+
+    // Version of the checker implementation. Bumped when the checker's
+    // scoring algorithm changes in a way that affects existing scores.
+    optional string checker_version = 7;
+  }
+}

--- a/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
+++ b/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
@@ -2,14 +2,13 @@ syntax = "proto3";
 
 package ai.pipestream.quality.v1;
 
+import "ai/pipestream/data/v1/pipeline_core_types.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-import "ai/pipestream/data/v1/pipeline_core_types.proto";
-
 option java_multiple_files = true;
-option java_package = "ai.pipestream.quality.v1";
 option java_outer_classname = "QualityProfile";
+option java_package = "ai.pipestream.quality.v1";
 
 // =============================================================================
 // QualityProfileService — Quality Profile Registry API

--- a/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
+++ b/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
@@ -1,0 +1,266 @@
+syntax = "proto3";
+
+package ai.pipestream.quality.v1;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+import "ai/pipestream/data/v1/pipeline_core_types.proto";
+
+option java_multiple_files = true;
+option java_package = "ai.pipestream.quality.v1";
+option java_outer_classname = "QualityProfile";
+
+// =============================================================================
+// QualityProfileService — Quality Profile Registry API
+// =============================================================================
+//
+// Parallels ChunkerConfigService and VectorSetService. Profiles are per-tenant
+// configuration defining which quality dimensions to assess, their weights,
+// and the composite method.
+//
+// Profile resolution priority (most specific wins):
+//   1. PipeDoc.ownership.datasource_id → profile with matching datasource_id
+//   2. PipeDoc.ownership.account_id → profile with matching account_id
+//   3. Default profile (account_id and datasource_id both empty)
+//   4. Built-in defaults (no profile in registry)
+//
+// This parallels how VectorSetDirectives are resolved: document-level
+// directive → config-level → service-level → built-in defaults.
+service QualityProfileService {
+  // Create a new quality profile.
+  rpc CreateQualityProfile(CreateQualityProfileRequest) returns (CreateQualityProfileResponse);
+
+  // Retrieve a quality profile by ID or name.
+  rpc GetQualityProfile(GetQualityProfileRequest) returns (GetQualityProfileResponse);
+
+  // Resolve the active profile for a document's ownership context.
+  // Implements the priority rules above.
+  rpc ResolveQualityProfile(ResolveQualityProfileRequest) returns (ResolveQualityProfileResponse);
+
+  // Update an existing quality profile. Increments the version field.
+  rpc UpdateQualityProfile(UpdateQualityProfileRequest) returns (UpdateQualityProfileResponse);
+
+  // Delete a quality profile by ID.
+  rpc DeleteQualityProfile(DeleteQualityProfileRequest) returns (DeleteQualityProfileResponse);
+
+  // List quality profiles with pagination.
+  rpc ListQualityProfiles(ListQualityProfilesRequest) returns (ListQualityProfilesResponse);
+}
+
+// =============================================================================
+// QualityProfile — per-tenant quality assessment configuration
+// =============================================================================
+
+message QualityProfile {
+  // Unique identifier for this profile (UUID).
+  string profile_id = 1;
+
+  // Human-readable name. Unique across all profiles.
+  // Example: "legal-team-v2", "research-strict", "default"
+  string name = 2;
+
+  // Resolution scope:
+  //   - both empty       → default profile (fallback for all tenants)
+  //   - account_id only  → profile applies to all datasources in the account
+  //   - both set         → profile applies to this specific datasource only
+  //   - datasource_id only → INVALID (must be paired with account_id)
+  optional string account_id = 3;
+  optional string datasource_id = 4;
+
+  // How the composite score is computed from dimension scores.
+  ai.pipestream.data.v1.QualityIndex.CompositeMethod composite_method = 5;
+
+  // Enabled dimensions with their weights and per-dimension config.
+  // Weights SHOULD sum to 1.0 — the service validates this at create/update.
+  repeated QualityDimensionConfig dimensions = 6;
+
+  // Documents scoring below this composite threshold trigger
+  // below_threshold_action. Range 0.0 - 1.0. Unset = no threshold.
+  optional float min_quality_threshold = 7;
+
+  // What to do with documents scoring below min_quality_threshold.
+  BelowThresholdAction below_threshold_action = 8;
+
+  // Profile version, incremented on every UpdateQualityProfile call.
+  // Preserved on QualityIndex.profile_version so historical assessments
+  // can be traced to the exact profile state that scored them.
+  string version = 9;
+
+  // Optional descriptive metadata for UI and audit.
+  optional string description = 10;
+  repeated string tags = 11;
+
+  google.protobuf.Timestamp created_at = 20;
+  google.protobuf.Timestamp updated_at = 21;
+  optional string created_by = 22;
+
+  // Action taken on documents scoring below min_quality_threshold.
+  enum BelowThresholdAction {
+    BELOW_THRESHOLD_ACTION_UNSPECIFIED = 0;
+    // Index the document but mark it as low-quality (filterable in search).
+    // The quality_index field is still populated — consumers can filter
+    // by quality_composite at query time.
+    BELOW_THRESHOLD_ACTION_INDEX_FLAGGED = 1;
+    // Skip indexing entirely — don't pollute the search index. The document
+    // still flows through the rest of the pipeline; the sink just drops it.
+    BELOW_THRESHOLD_ACTION_SKIP_INDEXING = 2;
+    // Route to a human review queue. The sink writes the document to a
+    // review topic/index instead of the main search index.
+    BELOW_THRESHOLD_ACTION_ROUTE_TO_REVIEW = 3;
+  }
+}
+
+// Configuration for a single quality dimension within a profile.
+message QualityDimensionConfig {
+  // Dimension identifier, matches QualityChecker.dimensionId().
+  // Must be a dimension ID returned by
+  // QualityAssessmentService.ListAvailableDimensions — the service rejects
+  // unknown IDs at create/update time.
+  string dimension_id = 1;
+
+  // Weight in composite calculation. Range 0.0 - 1.0.
+  // Weights across all dimensions in a profile SHOULD sum to 1.0.
+  float weight = 2;
+
+  // Dimension-specific configuration. Schema is defined by the individual
+  // QualityChecker — see DimensionDescriptor.config_schema from
+  // ListAvailableDimensions. Example for "recency":
+  //   { "half_life_days": 365 }
+  // Example for "authority":
+  //   { "trusted_domains": ["loc.gov", "nih.gov"] }
+  google.protobuf.Struct config = 3;
+
+  // Whether failure of this dimension aborts the whole assessment.
+  // When true: if the checker throws or returns an error, the entire
+  // QualityIndex is marked failed and the document is routed to the
+  // error path. When false: the dimension is silently omitted from the
+  // result and the composite is computed from the remaining dimensions.
+  // Default: false.
+  bool required = 4;
+
+  // Expected inputs this dimension requires. Overrides the checker's
+  // declared required_inputs for validation purposes — if the profile
+  // lists inputs the checker doesn't actually need, the service warns
+  // but does not reject. Mostly informational; use the checker's own
+  // required_inputs for skip-on-missing logic.
+  repeated QualityInput expected_inputs = 5;
+}
+
+// What inputs a quality dimension needs to compute its score. The quality
+// assessor uses this to skip dimensions whose inputs aren't available on
+// a given document (e.g. skip topic_relevance when no document vector has
+// been computed yet).
+//
+// Lives in this file because it is a core quality type — both QualityProfile
+// and QualityAssessmentService reference it, and moving it to a separate
+// file would fragment the bufmodule for no benefit.
+enum QualityInput {
+  QUALITY_INPUT_UNSPECIFIED = 0;
+  // PipeDoc.search_metadata base fields (title, body, author, dates, etc.)
+  QUALITY_INPUT_SEARCH_METADATA = 1;
+  // DocumentAnalytics / SourceFieldAnalytics — word counts, POS, lexical
+  // density, etc.
+  QUALITY_INPUT_DOCUMENT_ANALYTICS = 2;
+  // SemanticProcessingResult with chunks and embeddings.
+  QUALITY_INPUT_SEMANTIC_RESULTS = 3;
+  // A document-level centroid vector (GRANULARITY_LEVEL_DOCUMENT).
+  QUALITY_INPUT_DOCUMENT_VECTOR = 4;
+  // Raw parser outputs from PipeDoc.parsed_metadata (Tika, Docling, etc.).
+  QUALITY_INPUT_PARSED_METADATA = 5;
+  // Access to existing indexed documents in the corpus for duplication
+  // detection, cross-document similarity, etc.
+  QUALITY_INPUT_CORPUS_INDEX = 6;
+}
+
+// =============================================================================
+// CRUD messages
+// =============================================================================
+
+message CreateQualityProfileRequest {
+  // Optional ID (UUID). Omit to let the server generate one.
+  optional string profile_id = 1;
+  // Required: human-readable name, must be unique.
+  string name = 2;
+  optional string account_id = 3;
+  optional string datasource_id = 4;
+  ai.pipestream.data.v1.QualityIndex.CompositeMethod composite_method = 5;
+  repeated QualityDimensionConfig dimensions = 6;
+  optional float min_quality_threshold = 7;
+  QualityProfile.BelowThresholdAction below_threshold_action = 8;
+  optional string description = 9;
+  repeated string tags = 10;
+}
+
+message CreateQualityProfileResponse {
+  QualityProfile profile = 1;
+}
+
+message GetQualityProfileRequest {
+  // Profile ID (UUID) or name. Interpretation depends on by_name flag.
+  string id = 1;
+  // If true, id field is interpreted as a name lookup. Default false.
+  bool by_name = 2;
+}
+
+message GetQualityProfileResponse {
+  QualityProfile profile = 1;
+}
+
+// Resolve the active profile for an ownership context using the standard
+// priority rules (datasource → account → default).
+message ResolveQualityProfileRequest {
+  optional string account_id = 1;
+  optional string datasource_id = 2;
+}
+
+message ResolveQualityProfileResponse {
+  // The resolved profile. May be a default profile if no tenant-specific
+  // match exists.
+  QualityProfile profile = 1;
+  // Which matching strategy was used: "datasource", "account", or "default".
+  string match_type = 2;
+}
+
+message UpdateQualityProfileRequest {
+  // Required: profile ID to update.
+  string profile_id = 1;
+  // Optional: only fields explicitly set are updated.
+  optional string name = 2;
+  optional string account_id = 3;
+  optional string datasource_id = 4;
+  optional ai.pipestream.data.v1.QualityIndex.CompositeMethod composite_method = 5;
+  repeated QualityDimensionConfig dimensions = 6;
+  optional float min_quality_threshold = 7;
+  optional QualityProfile.BelowThresholdAction below_threshold_action = 8;
+  optional string description = 9;
+  repeated string tags = 10;
+}
+
+message UpdateQualityProfileResponse {
+  // The updated profile with incremented version and new updated_at.
+  QualityProfile profile = 1;
+}
+
+message DeleteQualityProfileRequest {
+  string profile_id = 1;
+}
+
+message DeleteQualityProfileResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+message ListQualityProfilesRequest {
+  // Page size, default 50, max 100.
+  int32 page_size = 1;
+  string page_token = 2;
+  // Optional filters.
+  optional string account_id = 3;
+  optional string datasource_id = 4;
+}
+
+message ListQualityProfilesResponse {
+  repeated QualityProfile profiles = 1;
+  string next_page_token = 2;
+}

--- a/semantic-indexing/proto/ai/pipestream/semantic/v1/semantic_indexing.proto
+++ b/semantic-indexing/proto/ai/pipestream/semantic/v1/semantic_indexing.proto
@@ -62,11 +62,13 @@ message StreamChunksRequest {
 // Typed chunker configuration — replaces opaque Struct.
 // The semantic-manager converts its JSON config to this proto before calling the chunker.
 message ChunkerConfig {
-  // Chunking algorithm: TOKEN (default), SENTENCE, CHARACTER, SEMANTIC.
+  // Chunking algorithm. Default: CHUNK_ALGORITHM_TOKEN.
   ChunkAlgorithm algorithm = 1;
   // Number of units (tokens, sentences, or characters) per chunk.
+  // Ignored for CHUNK_ALGORITHM_DOCLING (Docling defines chunk boundaries itself).
   int32 chunk_size = 2;
   // Number of overlapping units between consecutive chunks.
+  // Ignored for CHUNK_ALGORITHM_DOCLING.
   int32 chunk_overlap = 3;
   // Whether to clean/normalize text before chunking (collapse whitespace, normalize newlines).
   bool clean_text = 4;
@@ -74,6 +76,8 @@ message ChunkerConfig {
   bool preserve_urls = 5;
   // Semantic chunking configuration (only used when algorithm = CHUNK_ALGORITHM_SEMANTIC).
   optional SemanticChunkingConfig semantic_config = 6;
+  // Docling chunking configuration (only used when algorithm = CHUNK_ALGORITHM_DOCLING).
+  optional DoclingChunkingConfig docling_config = 7;
 }
 
 // Configuration for semantic (topic-boundary) chunking.
@@ -128,6 +132,49 @@ enum SectionSource {
   SECTION_SOURCE_DOCLING = 2;
 }
 
+// Configuration for Docling-native chunking.
+// Used when ChunkerConfig.algorithm = CHUNK_ALGORITHM_DOCLING.
+//
+// The chunker module reads Docling's chunks directly from
+// PipeDoc.parsed_metadata where parser_name = "docling" and emits them as
+// SemanticChunks. No chunking cost because Docling already produced them
+// during parse.
+//
+// If Docling data is not present in parsed_metadata, the chunker returns
+// PROCESSING_OUTCOME_SKIPPED with an explicit message. There is NO fallback
+// to other algorithms — if you configured DOCLING you get DOCLING or
+// nothing. Configure the pipeline so the Docling parser runs upstream of
+// the chunker when this algorithm is used.
+message DoclingChunkingConfig {
+  // Minimum character length for a Docling chunk to be emitted as-is.
+  // Chunks below this threshold are eligible for grouping (if
+  // group_small_chunks is true) or dropped outright. Default: 0 (emit all).
+  int32 min_chunk_chars = 1;
+
+  // When true, consecutive chunks below min_chunk_chars are aggregated into
+  // a larger chunk by concatenating their text and merging provenance.
+  // Grouping stops at the first non-small chunk or when the aggregated size
+  // reaches max_grouped_chunk_chars. Each grouped chunk keeps references to
+  // its source chunk IDs in ChunkProvenance.source_chunk_ids so consumers
+  // can trace back to the original Docling cells/fragments.
+  //
+  // Targets the common Docling pattern of producing tiny per-cell chunks
+  // (table cells, callouts, figure captions) that aren't individually
+  // useful but carry meaning when aggregated with their neighbors.
+  // Default: false.
+  bool group_small_chunks = 2;
+
+  // Upper bound for a grouped chunk when group_small_chunks is true.
+  // Grouping stops at this size even if more small chunks follow.
+  // Default: 2000.
+  int32 max_grouped_chunk_chars = 3;
+
+  // Whether to carry Docling's section/heading structure into ChunkProvenance.
+  // When true, the chunker sets provenance.section_id and heading_breadcrumb
+  // from the Docling document outline. Default: true.
+  bool populate_provenance = 4;
+}
+
 enum ChunkAlgorithm {
   CHUNK_ALGORITHM_UNSPECIFIED = 0;
   CHUNK_ALGORITHM_TOKEN = 1;
@@ -136,6 +183,10 @@ enum ChunkAlgorithm {
   // Semantic chunking: sentence-level embedding similarity for topic boundary detection.
   // Handled by the semantic manager orchestrator, not the chunker module.
   CHUNK_ALGORITHM_SEMANTIC = 4;
+  // Docling-native chunking: reuses chunks already produced by the Docling
+  // parser. Requires Docling data in PipeDoc.parsed_metadata; no fallback.
+  // Zero chunking cost. Configured via DoclingChunkingConfig.
+  CHUNK_ALGORITHM_DOCLING = 5;
 }
 
 // Entry in a multi-config chunking request.


### PR DESCRIPTION
## Summary

Two related proto changes from one session:

1. **Split `document_classification.proto`** (commit bb97c4f) — the 762-line monolith becomes a thin aggregator plus seven per-standard files (`premis_rights`, `dcmi_terms`, `ead_rights`, `mods_access_condition`, `odrl_policy`, `rights_statements`, `creative_commons_license`). Each standard is self-contained with its own XSD citations. Filenames are suffixed with the specific concept each file models so bare filenames stay unique across the whole proto tree. `dcmi_terms.proto` disambiguates from the parser-side `ai.pipestream.parsed.data.dublin.v1.dublin_core.proto`. Outer classnames drop the `Proto` suffix since the `v1` java package already disambiguates.

2. **Solidify granularity / pooling / provenance / docling / quality models** (commit 37665e0) — locks down proto vocabulary before the quality module and semantic refactor land any writes.

### Changes in commit 2

**`common/pipeline_core_types.proto`:**
- New `GranularityLevel` enum (SEMANTIC_CHUNK, SENTENCE, PARAGRAPH, SECTION, DOCUMENT) and `PoolingMethod` enum (DIRECT, MEAN, WEIGHTED_MEAN).
- `SemanticProcessingResult.semantic_granularity:string` → `granularity:GranularityLevel` at field 11. Add `pooling_method` (12) and `parent_result_id` (13) for hierarchy traversal.
- `CentroidMetadata.granularity:string` → `GranularityLevel` at field 1. Reconciles the previous string/string disagreement.
- New `ChunkProvenance` message wired as `SemanticChunk.provenance` field 6 (section_id → DocOutline.Section, heading_breadcrumb, parser_name, source_chunk_ids for pooled lineage, temporal seconds for audio/video).
- New `QualityIndex` and `QualityDimension` messages with `CompositeMethod` enum. Wired as `SearchMetadata.quality_index` field 27.

**`semantic-indexing/semantic_indexing.proto`:**
- New `CHUNK_ALGORITHM_DOCLING` (5) — reuses chunks from the Docling parser. No fallback: requires Docling data in `parsed_metadata` or fails with SKIPPED.
- New `DoclingChunkingConfig` (`min_chunk_chars`, `group_small_chunks`, `max_grouped_chunk_chars`, `populate_provenance`) as `ChunkerConfig.docling_config` field 7. Group-small-chunks targets Docling's tiny per-cell chunks (table cells, callouts) that aggregate meaningfully into larger units.

**`quality/` — new bufmodule (`buf.build/pipestreamai/quality`):**
- `quality_profile.proto` — `QualityProfileService` with CRUD + Resolve, `QualityProfile` with `BelowThresholdAction` enum (INDEX_FLAGGED, SKIP_INDEXING, ROUTE_TO_REVIEW), `QualityDimensionConfig`, `QualityInput` enum.
- `quality_assessment.proto` — `QualityAssessmentService` with `Assess` and `ListAvailableDimensions` RPCs. Standalone entry point for external re-scoring, testing, and ad-hoc audits. The pipeline quality module (via `PipeStepProcessorService`) delegates to the same underlying CDI bean — one code path, two entry points.

### Intentional breaking changes

- `CentroidMetadata.granularity`: string → enum at field 1
- `SemanticProcessingResult` field 11: `semantic_granularity:string` → `granularity:GranularityLevel`

Safe because **zero Java code writes or reads these fields** in the current codebase — verified by grep for `setSemanticGranularity` / `getSemanticGranularity` / `setCentroidMetadata` / `getCentroidMetadata` across all services. The fields were declared in a previous refactor but never wired up. Fixing the vocabulary now avoids doing a second migration later when quality scoring goes live.

## Test plan

- [x] `buf lint` — clean
- [x] `buf build` — clean
- [x] `buf breaking --against '.git'` — only the two intentional breaks reported above
- [ ] buf.build picks up the new `quality/` bufmodule on first push
- [ ] Downstream Java builds (pipestream-engine, pipestream-opensearch, etc.) still compile after rebuilding proto jars — to be verified in follow-up commits that start using the new types