### PR TITLE
proto: GraphNode consumer_slots + sidecar lease_key (for Kafka Consul consumer slots)

### DIFF
--- a/config/proto/ai/pipestream/config/v1/pipeline_config_models.proto
+++ b/config/proto/ai/pipestream/config/v1/pipeline_config_models.proto
@@ -156,6 +156,14 @@ message GraphNode {
   // Once the topic exists, this value is NOT used to alter it — changing partitions
   // on an existing topic requires a separate admin operation.
   int32 kafka_partitions = 20;
+
+  // Number of Consul consumer slot keys (lease slots) for this node's processing topic.
+  //
+  // Each slot is a separate KV key under pipestream/node-topics/{cluster}.{graph}.{node}/slotNN.
+  // The sidecar acquires at most one Kafka consumer group member per held slot.
+  // Clamped to kafka_partitions at registration time (extra slots would sit idle in Kafka).
+  // If 0 or unset, defaults to kafka_partitions (maximum useful parallelism for that topic).
+  int32 consumer_slots = 21;
 }
 
 // Dead Letter Queue configuration for handling failed messages.

--- a/engine-kafka-sidecar/proto/ai/pipestream/engine/sidecar/v1/management_service.proto
+++ b/engine-kafka-sidecar/proto/ai/pipestream/engine/sidecar/v1/management_service.proto
@@ -55,6 +55,8 @@ message LeaseInfo {
   string cluster_id = 6;
   // The consumer group this topic is assigned to.
   string consumer_group = 7;
+  // Consul KV key for this lease (slot path). Empty for single-row topics without per-slot visibility.
+  string lease_key = 8;
 }
 
 // Request to pause consumption for a topic.
@@ -109,14 +111,18 @@ message GraphConsumerConfig {
   repeated string topics = 4;
   // Current in-flight record count for this consumer.
   int32 in_flight_count = 5;
+  // When set, identifies a specific slot consumer (Consul lease path). Empty for the shared intake consumer.
+  string lease_key = 6;
 }
 
 // Request to update consumer configuration for a graph.
 message SetConsumerConfigRequest {
-  // The cluster ID (graph identifier) to configure.
+  // The cluster ID (graph identifier) to configure (intake / legacy grouping).
   string cluster_id = 1;
   // New max.poll.records value. 0 = use default.
   int32 max_poll_records = 2;
+  // If set, targets the slot consumer for this Consul lease key instead of cluster_id grouping.
+  string lease_key = 3;
 }
 
 // Response for setting consumer configuration.


### PR DESCRIPTION
## Summary

Rebases the safe half of the abandoned `feature/kafka-consul-consumer-slots` branch onto current main. Two additive-only proto commits that unblock pipestream-engine and pipestream-engine-kafka-sidecar against proto main.

Both of these services currently pin \`pipestreamProtosGitRef=feature/kafka-consul-consumer-slots\` in \`gradle.properties\` because they depend on these proto fields. That pin has been sitting since 2026-04-08 and is why the feature branch became load-bearing. This PR migrates the two safe field additions to main so the pin can be deleted.

## Commits

**\`ce689c0\` feat(config): GraphNode consumer_slots for Kafka sidecar lease slots**

Adds \`int32 consumer_slots = 21\` to \`GraphNode\` in \`config/proto/ai/pipestream/config/v1/pipeline_config_models.proto\`. Used by \`pipestream-engine/KafkaTopicRegistrar\` and \`NodeTopicSlotPlanner\` to compute Consul KV slot keys per processing topic. Field 21 is the next free number after \`kafka_partitions = 20\` (merged via #30).

**\`5cfb5c9\` feat(sidecar): lease_key on LeaseInfo and GraphConsumerConfig for slot consumers**

Adds \`string lease_key\` to three messages in \`engine-kafka-sidecar/proto/ai/pipestream/engine/sidecar/v1/management_service.proto\`:
- \`LeaseInfo.lease_key = 8\`
- \`GraphConsumerConfig.lease_key = 6\`
- \`ApplyGraphConsumerConfigRequest.lease_key = 3\`

Used by \`pipestream-engine-kafka-sidecar/SidecarManagementServiceImpl\` and \`ConsumerManager\` to identify which Consul slot a consumer group member holds.

## What's deferred

The original \`feature/kafka-consul-consumer-slots\` branch also had two commits that this PR intentionally excludes:
- \`a10c4e0\` feat(semantic-indexing): job-based chunker and embedder services (SemanticJobContext)
- \`30d5b31\` fix(semantic-indexing): align RPC types with buf STANDARD naming

Those commits rename \`SemanticChunkerService\` → \`SemanticChunkerJobService\` and \`SemanticEmbedderService\` → \`SemanticEmbedderJobService\` (along with all their request/response types), which would break Java code in three repos: module-chunker (implements chunker service), module-embedder (implements embedder service), module-semantic-manager (consumes both). That semantic refactor is unrelated to the engine/sidecar unblock and deserves its own focused cross-repo migration session.

## Test plan

- [x] \`buf lint\` — clean
- [x] \`buf build\` — clean
- [x] \`buf breaking --against '.git#ref=origin/main'\` — **clean (additive only)**
- [ ] After merge: delete \`pipestreamProtosGitRef=feature/kafka-consul-consumer-slots\` from \`pipestream-engine/gradle.properties\` and \`pipestream-engine-kafka-sidecar/gradle.properties\`, flatten their \`build.gradle\` \`pipestreamProtos\` blocks to literal \`gitRef = "main"\` (cross-repo PRs to follow)
- [ ] Independently: plan the semantic-indexing service refactor as a coordinated 4-repo PR set