### PR TITLE
fix(quality): rename outer class to resolve protoc collision

### DIFF
--- a/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
+++ b/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
@@ -7,7 +7,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 option java_multiple_files = true;
-option java_outer_classname = "QualityProfile";
+option java_outer_classname = "QualityProfileRegistry";
 option java_package = "ai.pipestream.quality.v1";
 
 // =============================================================================


### PR DESCRIPTION
## Problem

`quality_profile.proto` had `java_outer_classname = "QualityProfile"` which collides with the top-level `message QualityProfile` declared inside the same file. protoc refuses to generate Java:

```
--java_out: ai/pipestream/quality/v1/quality_profile.proto:
Cannot generate Java output because the file's outer class name,
"QualityProfile", matches the name of one of the types declared inside it.
Please either rename the type or use the java_outer_classname option.
```

This slipped through the initial audit in [#31](https://github.com/ai-pipestream/pipestream-protos/pull/31) when we dropped the `Proto` suffix from outer class names. The other files from that PR all have top-level types whose names don't match their outer class — this was the one slip-through.

## Fix

Renamed `java_outer_classname` from `QualityProfile` → `QualityProfileRegistry`. Semantically meaningful because the file contains `QualityProfileService` which IS the registry API (parallels `ChunkerConfigService` / `VectorSetService` naming).

## Breaking change?

Theoretical only. Since protoc couldn't generate Java for this file in the first place, no consumer could import from the old outer class name. Verified via grep across core-services and modules — zero references to `ai.pipestream.quality.v1.QualityProfile` as an outer-class-qualified name.

## Test plan

- [x] `buf lint` — clean
- [x] `buf build` — clean
- [x] `buf breaking` — only flags the outer classname change (expected, cosmetic)
- [ ] Downstream protoc runs should now succeed where they previously failed
