### PR TITLE
feat: rename account_id_prefix to account_id in CleanupTestDataSourcesRequest

### DIFF
--- a/intake/proto/ai/pipestream/connector/intake/v1/connector_intake_service.proto
+++ b/intake/proto/ai/pipestream/connector/intake/v1/connector_intake_service.proto
@@ -744,9 +744,9 @@ message CrawlSessionSummary {
 // --- CleanupTestDataSources ---
 
 message CleanupTestDataSourcesRequest {
-  // Prefix to match against account_id (e.g., "jdbc-e2e-" or "transport-e2e-").
-  // All datasources whose account_id starts with this prefix will be hard-deleted.
-  string account_id_prefix = 1;
+  // Account ID to match (e.g., "jdbc-e2e-123").
+  // All datasources for this account_id will be hard-deleted.
+  string account_id = 1;
 }
 
 message CleanupTestDataSourcesResponse {


### PR DESCRIPTION
This PR renames `account_id_prefix` to `account_id` in `CleanupTestDataSourcesRequest` to reflect the move to an exact-match implementation for better security and consistency.

Corresponding changes in `connector-admin` have been verified against this branch.