### PR TITLE
quality_profile

### DIFF
--- a/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
+++ b/quality/proto/ai/pipestream/quality/v1/quality_profile.proto
@@ -7,7 +7,7 @@ import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
 option java_multiple_files = true;
-option java_outer_classname = "QualityProfile";
+option java_outer_classname = "QualityProfileRegistry";
 option java_package = "ai.pipestream.quality.v1";
 
 // =============================================================================


### PR DESCRIPTION
This pull request makes a small update to the protobuf options in the `quality_profile.proto` file, changing the Java outer class name to improve naming consistency.

* Changed the `java_outer_classname` option from `QualityProfile` to `QualityProfileRegistry` in `quality_profile.proto` to better reflect its contents.