### PR TITLE
proto(common): add ChunkAnalytics content_hash + adverb_density + text_byte_size

### DIFF
--- a/common/proto/ai/pipestream/data/v1/pipeline_core_types.proto
+++ b/common/proto/ai/pipestream/data/v1/pipeline_core_types.proto
@@ -1339,6 +1339,27 @@ message ChunkAnalytics {
   int32 unique_lemma_count = 22;
   // Lexical density for this chunk.
   float lexical_density = 23;
+
+  // SHA-256 hex digest of the sanitised chunk text (lowercase, no separators,
+  // 64 chars). Identical sanitised text always produces the identical hash —
+  // enables reprocessing dedup, content-addressed embedder cache keys, and
+  // byte-verification of alternative chunker backends (e.g. an OpenVINO
+  // tokenizer) against this implementation. Computed by the chunker on the
+  // same text that lands in ChunkEmbedding.text_content.
+  string content_hash = 24;
+
+  // Chunk-local adverb ratio (0.0 to 1.0). Same semantics as
+  // NlpDocumentAnalysis.adverb_density but scoped to this chunk's token
+  // slice. Completes the POS-density set on ChunkAnalytics
+  // (noun/verb/adjective/adverb).
+  float adverb_density = 25;
+
+  // UTF-8 byte size of the chunk text. Distinct from character_count which
+  // counts Java chars (BMP code units). For ASCII text these are equal; for
+  // multi-byte UTF-8 (CJK, emoji, accented Latin), text_byte_size will be
+  // larger. Useful for storage planning at sinks (S3 part sizing, index
+  // budget, Kafka payload accounting).
+  int32 text_byte_size = 26;
 }
 
 // Analytics for a single (source_field, chunker_config) pair.


### PR DESCRIPTION
## Summary

Three new optional fields on \`ai.pipestream.data.v1.ChunkAnalytics\` for the chunker quick-wins series. **Pure additions — backward compatible** (\`buf breaking\` against main is clean, \`buf lint\` is clean, \`buf format -w\` made no changes).

## Fields

### \`content_hash\` (24, string)

SHA-256 hex digest of the sanitised chunk text (lowercase, no separators, 64 chars). Identical sanitised text → identical hash. Enables:

- **Reprocessing dedup** — same text → same hash → skip already-computed chunks at cache lookup
- **Content-addressed embedder cache keys** — embedder caches the text→vector mapping by hash, not by chunk_id
- **Byte-verification of alternative chunker backends** — e.g. an OpenVINO tokenizer swap can be verified against this implementation by hashing both outputs on the same input and comparing

Promoted from the loose \`SemanticChunk.metadata\` map where R1-pack-3 (PR #13 on module-chunker) originally added it. The typed proto field is the canonical home; the loose-map entry will be deleted in a follow-up after a consumer audit confirms no readers depend on the loose key.

### \`adverb_density\` (25, float)

Chunk-local adverb ratio, 0.0 to 1.0. Same semantics as \`NlpDocumentAnalysis.adverb_density\` (already field 8 there) but scoped to this chunk's token slice. Completes the POS-density set on \`ChunkAnalytics\` — the chunker's slice helper already counts adverbs (\`adverbs++\` at \`ChunkMetadataExtractor.java\` in the slice walk) but rolls them into \`content_word_ratio\` without a dedicated field. Adding the field exposes the value without changing the computation.

### \`text_byte_size\` (26, int32)

UTF-8 byte size of the chunk text. **Distinct from \`character_count\`** which counts Java chars (BMP code units). For ASCII text these are equal; for multi-byte UTF-8 (CJK, emoji, accented Latin) the byte size is larger. Useful for storage planning at sinks: S3 part sizing, index budget accounting, Kafka payload accounting, quarantine/DLQ size limits.

## Test plan

- [x] \`buf lint\` — clean
- [x] \`buf format -w\` — no changes
- [x] \`buf breaking --against .git#branch=main\` — clean
- [ ] CI green
- [ ] Merge ASAP so module-chunker can pull the new descriptors and write to the typed fields

## Downstream

Once this lands, **module-chunker PR-K2** wires the chunker's Path A and Path B to populate the three new typed fields. Initial ship will write to BOTH the typed field AND the loose map (additive, zero break). A later PR removes the loose-map duplication after a consumer audit.